### PR TITLE
Despawn furthest bot on bot spawn

### DIFF
--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -211,7 +211,7 @@ namespace Fika.Core.Coop.GameMode
         {
             List<CoopPlayer> humanPlayers = new List<CoopPlayer>();
 
-            //Grab all players
+            // Grab all players
             foreach (CoopPlayer player in coopHandler.Players.Values)
             {
                 if ((player.IsYourPlayer || player is ObservedCoopPlayer) && player.HealthController.IsAlive)
@@ -221,19 +221,21 @@ namespace Fika.Core.Coop.GameMode
             }
             return humanPlayers;
         }
+
         private float GetDistanceFromPlayers(Vector3 position, List<CoopPlayer> humanPlayers)
         {
             float distance = float.PositiveInfinity;
             foreach (Player player in humanPlayers)
             {
                 float tempDistance = Vector3.SqrMagnitude(position - player.Position);
-                if (tempDistance < distance) //Get the closest distance to any player. so we dont despawn bots in a players face.
+                if (tempDistance < distance) // Get the closest distance to any player. so we dont despawn bots in a players face.
                 {
                     distance = tempDistance;
                 }
             }
             return distance;
         }
+        
         private string GetFurthestBot(Dictionary<string, Player> bots, CoopHandler coopHandler, out float furthestDistance)
         {
             string furthestBot = string.Empty;
@@ -260,13 +262,13 @@ namespace Fika.Core.Coop.GameMode
                 WildSpawnType role = kvp.Value.Profile.Info.Settings.Role;
                 if ((int)role != sptUsecValue && (int)role != sptBearValue && role != EFT.WildSpawnType.assault)
                 {
-                    //We skip all the bots that are not sptUsec, sptBear or assault. That means we never remove bosses, bossfollowers, and raiders
+                    // We skip all the bots that are not sptUsec, sptBear or assault. That means we never remove bosses, bossfollowers, and raiders
                     continue;
                 }
 
                 float tempDistance = GetDistanceFromPlayers(kvp.Value.Position, humanPlayers);
 
-                if (tempDistance > furthestDistance) //We still want the furthest bot.
+                if (tempDistance > furthestDistance) // We still want the furthest bot.
                 {
                     furthestDistance = tempDistance;
                     furthestBot = kvp.Key;
@@ -310,7 +312,7 @@ namespace Fika.Core.Coop.GameMode
                     despawned = TryDespawnFurthest(profile, position, coopHandler);
                 }
 
-                //If it's not special and we didnt despawn something, we dont spawn a new bot.
+                // If it's not special and we didnt despawn something, we dont spawn a new bot.
                 if (!isSpecial && !despawned)
                 {
 #if DEBUG
@@ -427,7 +429,7 @@ namespace Fika.Core.Coop.GameMode
                 BotOwner botOwner = bot.AIData.BotOwner;
 
                 BotsController.Bots.Remove(botOwner);
-                bot.HealthController.DiedEvent -= botOwner.method_6; //Unsubscribe from the event to prevent errors.
+                bot.HealthController.DiedEvent -= botOwner.method_6; // Unsubscribe from the event to prevent errors.
                 BotUnspawn(botOwner);
                 botOwner?.Dispose();
 

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -245,19 +245,19 @@ namespace Fika.Core.Coop.GameMode
 
             List<CoopPlayer> humanPlayers = GetPlayers(coopHandler);
 
-            foreach (var kvp in Bots)
+            foreach (var botKeyValuePair in Bots)
             {
-                if( IsInvalidBotForDespawning(kvp) )
+                if( IsInvalidBotForDespawning(botKeyValuePair) )
                 {
                     continue;
                 }
 
-                float tempDistance = GetDistanceFromPlayers(kvp.Value.Position, humanPlayers);
+                float tempDistance = GetDistanceFromPlayers(botKeyValuePair.Value.Position, humanPlayers);
 
                 if (tempDistance > furthestDistance) // We still want the furthest bot.
                 {
                     furthestDistance = tempDistance;
-                    furthestBot = kvp.Key;
+                    furthestBot = botKeyValuePair.Key;
                 }
             }
 
@@ -418,9 +418,9 @@ namespace Fika.Core.Coop.GameMode
 
         private bool TryDespawnFurthest(Profile profile, Vector3 position, CoopHandler coopHandler)
         {
-            String botkey = GetFurthestBot(Bots, coopHandler, out float furthestDistance);
+            String botKey = GetFurthestBot(Bots, coopHandler, out float furthestDistance);
 
-            if (botkey == string.Empty)
+            if (botKey == string.Empty)
             {
                 return false;
             }
@@ -442,7 +442,7 @@ namespace Fika.Core.Coop.GameMode
                 return false;
             }
 
-            var bot = Bots[botkey];
+            Player bot = Bots[botKey];
 
 #if DEBUG
             Logger.LogWarning($"Removing {bot.Profile.Info.Settings.Role} at a distance of {Math.Sqrt(furthestDistance)}m from ITs nearest player.");
@@ -456,7 +456,7 @@ namespace Fika.Core.Coop.GameMode
             BotUnspawn(botOwner);
             botOwner?.Dispose();
 
-            Bots.Remove(botkey);
+            Bots.Remove(botKey);
             coopHandler.Players.Remove(bot.ProfileId);
 #if DEBUG
             Logger.LogWarning($"Bot {bot.Profile.Info.Settings.Role} despawned successfully.");

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -229,7 +229,7 @@ namespace Fika.Core.Coop.GameMode
             foreach (Player player in humanPlayers)
             {
                 float tempDistance = Vector3.SqrMagnitude(position - player.Position);
-                
+
                 if (tempDistance < distance) // Get the closest distance to any player. so we dont despawn bots in a players face.
                 {
                     distance = tempDistance;
@@ -410,47 +410,48 @@ namespace Fika.Core.Coop.GameMode
         {
             String botkey = GetFurthestBot(Bots, coopHandler, out float furthestDistance);
 
-            if (botkey != string.Empty)
+            if (botkey == string.Empty)
             {
-                if (furthestDistance > GetDistanceFromPlayers(position, GetPlayers(coopHandler)))
-                {
-#if DEBUG
-                    Logger.LogWarning($"We're not despawning anything. The furthest bot is closer than the one we wanted to spawn.");
-#endif
-                    return false;
-                }
-
-                //Dont despawn inside of dynamic AI range
-                if (furthestDistance < FikaPlugin.DynamicAIRange.Value * FikaPlugin.DynamicAIRange.Value) //Square it because we use sqrMagnitude for distance calculation
-                {
-#if DEBUG
-                    Logger.LogWarning($"We're not despawning anything. Furthest despawnable bot is inside DynamicAI range.");
-#endif
-                    return false;
-                }
-
-                var bot = Bots[botkey];
-
-#if DEBUG
-                Logger.LogWarning($"Removing {bot.Profile.Info.Settings.Role} at a distance of {Math.Sqrt(furthestDistance)}m from ITs nearest player.");
-#endif
-
-                IBotGame botGame = Singleton<IBotGame>.Instance;
-                BotOwner botOwner = bot.AIData.BotOwner;
-
-                BotsController.Bots.Remove(botOwner);
-                bot.HealthController.DiedEvent -= botOwner.method_6; // Unsubscribe from the event to prevent errors.
-                BotUnspawn(botOwner);
-                botOwner?.Dispose();
-
-                Bots.Remove(botkey);
-                coopHandler.Players.Remove(bot.ProfileId);
-#if DEBUG
-                Logger.LogWarning($"Bot {bot.Profile.Info.Settings.Role} despawned successfully.");
-#endif  
-                return true;
+                return false;
             }
-            return false;
+            
+            if (furthestDistance > GetDistanceFromPlayers(position, GetPlayers(coopHandler)))
+            {
+#if DEBUG
+                Logger.LogWarning($"We're not despawning anything. The furthest bot is closer than the one we wanted to spawn.");
+#endif
+                return false;
+            }
+
+            //Dont despawn inside of dynamic AI range
+            if (furthestDistance < FikaPlugin.DynamicAIRange.Value * FikaPlugin.DynamicAIRange.Value) //Square it because we use sqrMagnitude for distance calculation
+            {
+#if DEBUG
+                Logger.LogWarning($"We're not despawning anything. Furthest despawnable bot is inside DynamicAI range.");
+#endif
+                return false;
+            }
+
+            var bot = Bots[botkey];
+
+#if DEBUG
+            Logger.LogWarning($"Removing {bot.Profile.Info.Settings.Role} at a distance of {Math.Sqrt(furthestDistance)}m from ITs nearest player.");
+#endif
+
+            IBotGame botGame = Singleton<IBotGame>.Instance;
+            BotOwner botOwner = bot.AIData.BotOwner;
+
+            BotsController.Bots.Remove(botOwner);
+            bot.HealthController.DiedEvent -= botOwner.method_6; // Unsubscribe from the event to prevent errors.
+            BotUnspawn(botOwner);
+            botOwner?.Dispose();
+
+            Bots.Remove(botkey);
+            coopHandler.Players.Remove(bot.ProfileId);
+#if DEBUG
+            Logger.LogWarning($"Bot {bot.Profile.Info.Settings.Role} despawned successfully.");
+#endif
+            return true;
         }
 
         /// <summary>

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -56,7 +56,8 @@ namespace Fika.Core.Coop.GameMode
         public bool forceStart = false;
         private CoopExfilManager exfilManager;
         private GameObject fikaStartButton;
-
+        
+        //WildSpawnType for sptUsec and sptBear
         const int sptUsecValue = 47;
         const int sptBearValue = 48;
 

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -247,29 +247,8 @@ namespace Fika.Core.Coop.GameMode
 
             foreach (var kvp in Bots)
             {
-                if (kvp.Value == null || kvp.Value == null || kvp.Value.Position == null)
+                if( IsInvalidBot(kvp) )
                 {
-#if DEBUG
-                    Logger.LogWarning("Bot is null, skipping");
-#endif
-                    continue;
-                }
-
-                CoopBot coopBot = (CoopBot)kvp.Value;
-
-                if (coopBot != null && coopBot.isStarted == false)
-                {
-#if DEBUG
-                    Logger.LogWarning("Bot is not started, skipping");
-#endif
-                    continue;
-                }
-
-                WildSpawnType role = kvp.Value.Profile.Info.Settings.Role;
-
-                if ((int)role != sptUsecValue && (int)role != sptBearValue && role != EFT.WildSpawnType.assault)
-                {
-                    // We skip all the bots that are not sptUsec, sptBear or assault. That means we never remove bosses, bossfollowers, and raiders
                     continue;
                 }
 
@@ -283,6 +262,37 @@ namespace Fika.Core.Coop.GameMode
             }
 
             return furthestBot;
+        }
+
+        private bool IsInvalidBot(KeyValuePair<string, Player> kvp)
+        {
+            if (kvp.Value == null || kvp.Value == null || kvp.Value.Position == null)
+            {
+#if DEBUG
+                Logger.LogWarning("Bot is null, skipping");
+#endif
+                return true;
+            }
+
+            CoopBot coopBot = (CoopBot)kvp.Value;
+
+            if (coopBot != null && coopBot.isStarted == false)
+            {
+#if DEBUG
+                Logger.LogWarning("Bot is not started, skipping");
+#endif
+                return true;
+            }
+
+            WildSpawnType role = kvp.Value.Profile.Info.Settings.Role;
+
+            if ((int)role != sptUsecValue && (int)role != sptBearValue && role != EFT.WildSpawnType.assault)
+            {
+                // We skip all the bots that are not sptUsec, sptBear or assault. That means we never remove bosses, bossfollowers, and raiders
+                return true;
+            }
+
+            return false;
         }
 
         private async Task<LocalPlayer> CreatePhysicalBot(Profile profile, Vector3 position)
@@ -414,7 +424,7 @@ namespace Fika.Core.Coop.GameMode
             {
                 return false;
             }
-            
+
             if (furthestDistance > GetDistanceFromPlayers(position, GetPlayers(coopHandler)))
             {
 #if DEBUG

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -225,9 +225,11 @@ namespace Fika.Core.Coop.GameMode
         private float GetDistanceFromPlayers(Vector3 position, List<CoopPlayer> humanPlayers)
         {
             float distance = float.PositiveInfinity;
+
             foreach (Player player in humanPlayers)
             {
                 float tempDistance = Vector3.SqrMagnitude(position - player.Position);
+                
                 if (tempDistance < distance) // Get the closest distance to any player. so we dont despawn bots in a players face.
                 {
                     distance = tempDistance;
@@ -235,11 +237,12 @@ namespace Fika.Core.Coop.GameMode
             }
             return distance;
         }
-        
+
         private string GetFurthestBot(Dictionary<string, Player> bots, CoopHandler coopHandler, out float furthestDistance)
         {
             string furthestBot = string.Empty;
             furthestDistance = 0f;
+
             List<CoopPlayer> humanPlayers = GetPlayers(coopHandler);
 
             foreach (var kvp in Bots)
@@ -251,7 +254,9 @@ namespace Fika.Core.Coop.GameMode
 #endif
                     continue;
                 }
+
                 CoopBot coopBot = (CoopBot)kvp.Value;
+
                 if (coopBot != null && coopBot.isStarted == false)
                 {
 #if DEBUG
@@ -259,7 +264,9 @@ namespace Fika.Core.Coop.GameMode
 #endif
                     continue;
                 }
+
                 WildSpawnType role = kvp.Value.Profile.Info.Settings.Role;
+
                 if ((int)role != sptUsecValue && (int)role != sptBearValue && role != EFT.WildSpawnType.assault)
                 {
                     // We skip all the bots that are not sptUsec, sptBear or assault. That means we never remove bosses, bossfollowers, and raiders
@@ -307,6 +314,7 @@ namespace Fika.Core.Coop.GameMode
             if (FikaPlugin.EnforcedSpawnLimits.Value && botsController_0.AliveAndLoadingBotsCount >= botsController_0.BotSpawner.MaxBots)
             {
                 bool despawned = false;
+
                 if (FikaPlugin.DespawnFurthest.Value)
                 {
                     despawned = TryDespawnFurthest(profile, position, coopHandler);
@@ -323,6 +331,7 @@ namespace Fika.Core.Coop.GameMode
             }
 
             LocalPlayer localPlayer;
+
             if (!Status.IsRunned())
             {
                 localPlayer = null;
@@ -342,6 +351,7 @@ namespace Fika.Core.Coop.GameMode
                    () => 1f, GClass1446.Default);
 
                 localPlayer.Location = Location_0.Id;
+
                 if (Bots.ContainsKey(localPlayer.ProfileId))
                 {
                     Destroy(localPlayer);

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -247,7 +247,7 @@ namespace Fika.Core.Coop.GameMode
 
             foreach (var kvp in Bots)
             {
-                if( IsInvalidBot(kvp) )
+                if( IsInvalidBotForDespawning(kvp) )
                 {
                     continue;
                 }

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -238,7 +238,7 @@ namespace Fika.Core.Coop.GameMode
         {
             string furthestBot = string.Empty;
             furthestDistance = 0f;
-            var humanPlayers = GetPlayers(coopHandler);
+            List<CoopPlayer> humanPlayers = GetPlayers(coopHandler);
 
             foreach (var kvp in Bots)
             {
@@ -249,7 +249,7 @@ namespace Fika.Core.Coop.GameMode
 #endif
                     continue;
                 }
-                var coopBot = (CoopBot)kvp.Value;
+                CoopBot coopBot = (CoopBot)kvp.Value;
                 if (coopBot != null && coopBot.isStarted == false)
                 {
 #if DEBUG
@@ -307,7 +307,7 @@ namespace Fika.Core.Coop.GameMode
                 {
                     try
                     {
-                        var botkey = GetFurthestBot(Bots, coopHandler, out float furthestDistance);
+                        String botkey = GetFurthestBot(Bots, coopHandler, out float furthestDistance);
 
                         if (furthestDistance > GetDistanceFromPlayers(position, GetPlayers(coopHandler)))
                         {
@@ -321,15 +321,15 @@ namespace Fika.Core.Coop.GameMode
                             return null;
                         }
 
-                        var bot = Bots[botkey];
+                        bool botExists = Bots.TryGetValue(botkey, out Player bot);
 
 #if DEBUG
                         //sqrt is slow, but this is just for debugging anyway.
                         Logger.LogWarning($"Removing {bot.Profile.Info.Settings.Role} at a distance of {Math.Sqrt(furthestDistance)}m from ITs nearest player.");
 #endif
 
-                        var botGame = Singleton<IBotGame>.Instance;
-                        var botOwner = bot.AIData.BotOwner;
+                        IBotGame botGame = Singleton<IBotGame>.Instance;
+                        BotOwner botOwner = bot.AIData.BotOwner;
 
                         BotsController.Bots.Remove(botOwner);
                         bot.HealthController.DiedEvent -= botOwner.method_6; //Unsubscribe from the event to prevent errors.

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -56,7 +56,7 @@ namespace Fika.Core.Coop.GameMode
         public bool forceStart = false;
         private CoopExfilManager exfilManager;
         private GameObject fikaStartButton;
-        
+
         //WildSpawnType for sptUsec and sptBear
         const int sptUsecValue = 47;
         const int sptBearValue = 48;
@@ -321,6 +321,7 @@ namespace Fika.Core.Coop.GameMode
                         botOwner?.Dispose();
 
                         Bots.Remove(botkey);
+                        coopHandler.Players.Remove(bot.ProfileId);
 #if DEBUG
                         Logger.LogWarning($"Bot {bot.Profile.Info.Settings.Role} despawned successfully.");
 #endif

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -264,7 +264,7 @@ namespace Fika.Core.Coop.GameMode
             return furthestBot;
         }
 
-        private bool IsInvalidBot(KeyValuePair<string, Player> kvp)
+        private bool IsInvalidBotForDespawning(KeyValuePair<string, Player> kvp)
         {
             if (kvp.Value == null || kvp.Value == null || kvp.Value.Position == null)
             {

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -285,9 +285,9 @@ namespace Fika.Core
 
             // Performance | Max Bots
 
-            EnforcedSpawnLimits = Config.Bind("Performance | Max Bots", "Enforced Spawn Limits", false, new ConfigDescription("Enforces spawn limits when spawning bots, making sure to not go over the vanilla limits. This mainly takes affect when using spawn mods or anything that modifies the bot limits.", tags: new ConfigurationManagerAttributes() { Order = 13 }));
+            EnforcedSpawnLimits = Config.Bind("Performance | Max Bots", "Enforced Spawn Limits", false, new ConfigDescription("Enforces spawn limits when spawning bots, making sure to not go over the vanilla limits. This mainly takes affect when using spawn mods or anything that modifies the bot limits. Will not block spawns of special bots like bosses.", tags: new ConfigurationManagerAttributes() { Order = 13 }));
 
-            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid on a lower Max Bots count. Helpful for lower-end PCs", tags: new ConfigurationManagerAttributes() { Order = 12 }));
+            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid on a lower Max Bots count. Helpful for weaker PCs. Will only despawn pmcs and scavs.", tags: new ConfigurationManagerAttributes() { Order = 12 }));
 
             MaxBotsFactory = Config.Bind("Performance | Max Bots", "Max Bots Factory", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Factory. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 11 }));
 

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -117,6 +117,8 @@ namespace Fika.Core
         public static ConfigEntry<KeyboardShortcut> FreeCamButton { get; set; }
         // Performance
         public static ConfigEntry<bool> EnforcedSpawnLimits { get; set; }
+
+        public static ConfigEntry<bool> DespawnFurthest { get; set; }
         public static ConfigEntry<bool> DynamicAI { get; set; }
         public static ConfigEntry<float> DynamicAIRange { get; set; }
         public static ConfigEntry<DynamicAIRates> DynamicAIRate { get; set; }
@@ -283,27 +285,29 @@ namespace Fika.Core
 
             // Performance | Max Bots
 
-            EnforcedSpawnLimits = Config.Bind("Performance | Max Bots", "Enforced Spawn Limits", false, new ConfigDescription("Enforces spawn limits when spawning bots, making sure to not go over the vanilla limits. This mainly takes affect when using spawn mods or anything that modifies the bot limits.", tags: new ConfigurationManagerAttributes() { Order = 12 }));
+            EnforcedSpawnLimits = Config.Bind("Performance | Max Bots", "Enforced Spawn Limits", false, new ConfigDescription("Enforces spawn limits when spawning bots, making sure to not go over the vanilla limits. This mainly takes affect when using spawn mods or anything that modifies the bot limits.", tags: new ConfigurationManagerAttributes() { Order = 13 }));
 
-            MaxBotsFactory = Config.Bind("Performance | Max Bots", "Max Bots Factory", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Factory. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 11 }));
+            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid, and is helpful on lower-end PCs with a low Max Bots count.", tags: new ConfigurationManagerAttributes() { Order = 12 }));
 
-            MaxBotsCustoms = Config.Bind("Performance | Max Bots", "Max Bots Customs", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Customs. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 10 }));
+            MaxBotsFactory = Config.Bind("Performance | Max Bots", "Max Bots Factory", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Factory. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 11 }));
 
-            MaxBotsInterchange = Config.Bind("Performance | Max Bots", "Max Bots Interchange", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Interchange. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 8 }));
+            MaxBotsCustoms = Config.Bind("Performance | Max Bots", "Max Bots Customs", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Customs. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 10 }));
 
-            MaxBotsReserve = Config.Bind("Performance | Max Bots", "Max Bots Reserve", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Reserve. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 7 }));
+            MaxBotsInterchange = Config.Bind("Performance | Max Bots", "Max Bots Interchange", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Interchange. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 8 }));
 
-            MaxBotsWoods = Config.Bind("Performance | Max Bots", "Max Bots Woods", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Woods. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 6 }));
+            MaxBotsReserve = Config.Bind("Performance | Max Bots", "Max Bots Reserve", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Reserve. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 7 }));
 
-            MaxBotsShoreline = Config.Bind("Performance | Max Bots", "Max Bots Shoreline", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Shoreline. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 5 }));
+            MaxBotsWoods = Config.Bind("Performance | Max Bots", "Max Bots Woods", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Woods. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 6 }));
 
-            MaxBotsStreets = Config.Bind("Performance | Max Bots", "Max Bots Streets", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Streets of Tarkov. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 4 }));
+            MaxBotsShoreline = Config.Bind("Performance | Max Bots", "Max Bots Shoreline", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Shoreline. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 5 }));
 
-            MaxBotsGroundZero = Config.Bind("Performance | Max Bots", "Max Bots Ground Zero", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Ground Zero. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 3 }));
+            MaxBotsStreets = Config.Bind("Performance | Max Bots", "Max Bots Streets", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Streets of Tarkov. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 4 }));
 
-            MaxBotsLabs = Config.Bind("Performance | Max Bots", "Max Bots Labs", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Labs. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 2 }));
+            MaxBotsGroundZero = Config.Bind("Performance | Max Bots", "Max Bots Ground Zero", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Ground Zero. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 3 }));
 
-            MaxBotsLighthouse = Config.Bind("Performance | Max Bots", "Max Bots Lighthouse", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Lighthouse. Useful if you have a weaker PC. Set to 0 to disable.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 1 }));
+            MaxBotsLabs = Config.Bind("Performance | Max Bots", "Max Bots Labs", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Labs. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 2 }));
+
+            MaxBotsLighthouse = Config.Bind("Performance | Max Bots", "Max Bots Lighthouse", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Lighthouse. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 1 }));
 
             // Network
 

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -287,7 +287,7 @@ namespace Fika.Core
 
             EnforcedSpawnLimits = Config.Bind("Performance | Max Bots", "Enforced Spawn Limits", false, new ConfigDescription("Enforces spawn limits when spawning bots, making sure to not go over the vanilla limits. This mainly takes affect when using spawn mods or anything that modifies the bot limits.", tags: new ConfigurationManagerAttributes() { Order = 13 }));
 
-            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid, and is helpful on lower-end PCs with a low Max Bots count.", tags: new ConfigurationManagerAttributes() { Order = 12 }));
+            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid on a lower Max Bots count. Helpful for lower-end PCs", tags: new ConfigurationManagerAttributes() { Order = 12 }));
 
             MaxBotsFactory = Config.Bind("Performance | Max Bots", "Max Bots Factory", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Factory. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 11 }));
 

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -287,7 +287,7 @@ namespace Fika.Core
 
             EnforcedSpawnLimits = Config.Bind("Performance | Max Bots", "Enforced Spawn Limits", false, new ConfigDescription("Enforces spawn limits when spawning bots, making sure to not go over the vanilla limits. This mainly takes affect when using spawn mods or anything that modifies the bot limits. Will not block spawns of special bots like bosses.", tags: new ConfigurationManagerAttributes() { Order = 13 }));
 
-            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid on a lower Max Bots count. Helpful for weaker PCs. Will only despawn pmcs and scavs.", tags: new ConfigurationManagerAttributes() { Order = 12 }));
+            DespawnFurthest = Config.Bind("Performance | Max Bots", "Despawn Furthest", false, new ConfigDescription("When enforcing spawn limits, should the furthest bot be de-spawned instead of blocking the spawn. This will make for a much more active raid on a lower Max Bots count. Helpful for weaker PCs. Will only despawn pmcs and scavs. If you don't run a dynamic spawn mod, this will however quickly exhaust the spawns on the map, making the raid very dead instead.", tags: new ConfigurationManagerAttributes() { Order = 12 }));
 
             MaxBotsFactory = Config.Bind("Performance | Max Bots", "Max Bots Factory", 0, new ConfigDescription("Max amount of bots that can be active at the same time on Factory. Useful if you have a weaker PC. Set to 0 to use vanilla limits.", new AcceptableValueRange<int>(0, 50), new ConfigurationManagerAttributes() { Order = 11 }));
 


### PR DESCRIPTION
Been tested by my group for more than 50+ raids. With MASSIVE fps improvements. (in some cases double fps) 
It also fixes one inherent issues with bot limits: before bosses could get blocked. They always get spawned now.
Spawning always cause some minor stutters. Technically not this code at fault. But it does allow for more opportunities to spawn things.  (Perhaps should be added to description of the setting in the plugin menu?) But personally, Ill take double fps for a tiny stutter every now and then.