### PR TITLE
Fix for WorldToScreen with zoomed scopes

### DIFF
--- a/Fika.Core/Coop/Custom/FikaHealthBar.cs
+++ b/Fika.Core/Coop/Custom/FikaHealthBar.cs
@@ -6,6 +6,7 @@ using EFT.Animations;
 using EFT.UI;
 using Fika.Core.Bundles;
 using Fika.Core.Coop.Players;
+using Fika.Core.Utils;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -98,9 +99,8 @@ namespace Fika.Core.Coop.Custom
 
             float processedDistance = Mathf.Clamp(sqrDistance / 625, 0.6f, 1f);
             Vector3 position = new(currentPlayer.PlayerBones.Neck.position.x, currentPlayer.PlayerBones.Neck.position.y + (1f * processedDistance), currentPlayer.PlayerBones.Neck.position.z);
-            Vector3 screenPoint = camera.WorldToScreenPoint(position);
-
-            if (screenPoint.z <= 0)
+            
+            if (WorldToScreen.GetScreenPoint(position, mainPlayer, out Vector3 screenPoint) == false)
             {
                 UpdateColorTextMeshProUGUI(playerPlate.playerNameScreen, 0);
                 UpdateColorImage(playerPlate.healthBarScreen, 0);

--- a/Fika.Core/Coop/Custom/FikaHealthBar.cs
+++ b/Fika.Core/Coop/Custom/FikaHealthBar.cs
@@ -100,7 +100,7 @@ namespace Fika.Core.Coop.Custom
             float processedDistance = Mathf.Clamp(sqrDistance / 625, 0.6f, 1f);
             Vector3 position = new(currentPlayer.PlayerBones.Neck.position.x, currentPlayer.PlayerBones.Neck.position.y + (1f * processedDistance), currentPlayer.PlayerBones.Neck.position.z);
             
-            if (WorldToScreen.GetScreenPoint(position, mainPlayer, out Vector3 screenPoint) == false)
+            if (!WorldToScreen.GetScreenPoint(position, mainPlayer, out Vector3 screenPoint))
             {
                 UpdateColorTextMeshProUGUI(playerPlate.playerNameScreen, 0);
                 UpdateColorImage(playerPlate.healthBarScreen, 0);

--- a/Fika.Core/Coop/Factories/PingFactory.cs
+++ b/Fika.Core/Coop/Factories/PingFactory.cs
@@ -82,7 +82,6 @@ public static class PingFactory
 
             if (mainPlayer.ProceduralWeaponAnimation.IsAiming && mainPlayer.ProceduralWeaponAnimation.CurrentScope.IsOptic)
             {
-                //SightComponent currentSightComponent = mainPlayer.ProceduralWeaponAnimation.CurrentScope.Mod;
                 SightComponent currentSightComponent = mainPlayer.ProceduralWeaponAnimation.CurrentAimingMod;
 
                 if (currentSightComponent != null)
@@ -101,18 +100,19 @@ public static class PingFactory
 
                             if (currentOptic != null)
                             {
-                                Vector3 opticCenterScreenPosition = camera.WorldToScreenPoint(currentOptic.LensRenderer.transform.position);
+                                Transform opticLensTransform = currentOptic.LensRenderer.transform;
+                                Vector3 opticCenterScreenPosition = camera.WorldToScreenPoint(opticLensTransform.position);
                                 Vector3 opticCenterScreenOffset = opticCenterScreenPosition - (new Vector3(Screen.width, Screen.height, 0) / 2);
 
-                                //TO-DO?: calculate optic radius & don't use optic camera to render if distance from middle of screen is > radius
-
                                 //calculate where the zoomed in camera & world camera correspond to each other
-                                float opticScale = Screen.height / opticCamera.scaledPixelHeight;
+                                float opticScale = (Screen.height / opticCamera.scaledPixelHeight);
                                 Vector3 opticCameraOffset = new Vector3(x: (camera.pixelWidth / 2 - opticCamera.pixelWidth / 2), y: (camera.pixelHeight / 2 - opticCamera.pixelHeight / 2), z: 0);
                                 Vector3 scopeScreenPoint = (opticCamera.WorldToScreenPoint(hitPoint) + opticCameraOffset) * opticScale;
 
-                                screenPoint = scopeScreenPoint + opticCenterScreenOffset;
-                                //screenPoint = scopeScreenPoint;
+                                if (scopeScreenPoint.z > 0)
+                                {
+                                    screenPoint = scopeScreenPoint + opticCenterScreenOffset;
+                                }
                             }
                         }
                     }

--- a/Fika.Core/Coop/Factories/PingFactory.cs
+++ b/Fika.Core/Coop/Factories/PingFactory.cs
@@ -4,6 +4,7 @@ using EFT.CameraControl;
 using EFT.InventoryLogic;
 using Fika.Core.Bundles;
 using Fika.Core.Coop.Players;
+using Fika.Core.Utils;
 using UnityEngine;
 using UnityEngine.UI;
 using Object = System.Object;
@@ -77,54 +78,6 @@ public static class PingFactory
                 }
             }
 
-            Camera camera = CameraClass.Instance.Camera;
-            Vector3 screenPoint = Vector3.zero;
-
-            if (mainPlayer.ProceduralWeaponAnimation.IsAiming && mainPlayer.ProceduralWeaponAnimation.CurrentScope.IsOptic)
-            {
-                SightComponent currentSightComponent = mainPlayer.ProceduralWeaponAnimation.CurrentAimingMod;
-
-                if (currentSightComponent != null)
-                {
-                    float opticZoomLevel = currentSightComponent.GetCurrentOpticZoom();
-
-                    //only calculate optic screen point if zoom is higher than 1
-                    if (opticZoomLevel > 1.0f)
-                    {
-                        Camera opticCamera = CameraClass.Instance.OpticCameraManager.Camera;
-
-                        if (opticCamera != null)
-                        {
-                            //calculate where the optic is relative to the center of the screen due to weapon sway
-                            OpticSight currentOptic = mainPlayer.ProceduralWeaponAnimation.HandsContainer.Weapon.GetComponentInChildren<OpticSight>();
-
-                            if (currentOptic != null)
-                            {
-                                Transform opticLensTransform = currentOptic.LensRenderer.transform;
-                                Vector3 opticCenterScreenPosition = camera.WorldToScreenPoint(opticLensTransform.position);
-                                Vector3 opticCenterScreenOffset = opticCenterScreenPosition - (new Vector3(Screen.width, Screen.height, 0) / 2);
-
-                                //calculate where the zoomed in camera & world camera correspond to each other
-                                float opticScale = (Screen.height / opticCamera.scaledPixelHeight);
-                                Vector3 opticCameraOffset = new Vector3(x: (camera.pixelWidth / 2 - opticCamera.pixelWidth / 2), y: (camera.pixelHeight / 2 - opticCamera.pixelHeight / 2), z: 0);
-                                Vector3 scopeScreenPoint = (opticCamera.WorldToScreenPoint(hitPoint) + opticCameraOffset) * opticScale;
-
-                                if (scopeScreenPoint.z > 0)
-                                {
-                                    screenPoint = scopeScreenPoint + opticCenterScreenOffset;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            //no optic, not aiming, or optic is not zoomed (thus no pip camera component)
-            if (screenPoint ==  Vector3.zero)
-            {
-                screenPoint = camera.WorldToScreenPoint(hitPoint);
-            }
-
             if (CameraClass.Instance.SSAA != null && CameraClass.Instance.SSAA.isActiveAndEnabled)
             {
                 int outputWidth = CameraClass.Instance.SSAA.GetOutputWidth();
@@ -132,7 +85,7 @@ public static class PingFactory
                 screenScale = outputWidth / inputWidth;
             }
 
-            if (screenPoint.z > 0)
+            if (WorldToScreen.GetScreenPoint(hitPoint, mainPlayer, out Vector3 screenPoint))
             {
                 float distanceToCenter = Vector3.Distance(screenPoint, new Vector3(x: Screen.width, y: Screen.height, 0) / 2);
 

--- a/Fika.Core/Coop/Factories/PingFactory.cs
+++ b/Fika.Core/Coop/Factories/PingFactory.cs
@@ -85,7 +85,7 @@ public static class PingFactory
 
             if (WorldToScreen.GetScreenPoint(hitPoint, mainPlayer, out Vector3 screenPoint))
             {
-                float distanceToCenter = Vector3.Distance(screenPoint, new Vector3(x: Screen.width, y: Screen.height, 0) / 2);
+                float distanceToCenter = Vector3.Distance(screenPoint, new Vector3(Screen.width, Screen.height, 0) / 2);
 
                 if (distanceToCenter < 200)
                 {

--- a/Fika.Core/Coop/Factories/PingFactory.cs
+++ b/Fika.Core/Coop/Factories/PingFactory.cs
@@ -1,7 +1,5 @@
 ﻿using Comfort.Common;
 using EFT;
-using EFT.CameraControl;
-using EFT.InventoryLogic;
 using Fika.Core.Bundles;
 using Fika.Core.Coop.Players;
 using Fika.Core.Utils;

--- a/Fika.Core/Utils/WorldToScreen.cs
+++ b/Fika.Core/Utils/WorldToScreen.cs
@@ -1,0 +1,77 @@
+﻿using EFT.Animations;
+using EFT.CameraControl;
+using EFT.InventoryLogic;
+using Fika.Core.Coop.Players;
+using UnityEngine;
+
+namespace Fika.Core.Utils
+{
+    public static class WorldToScreen
+    {
+        public static bool GetScreenPoint(Vector3 worldPosition, CoopPlayer mainPlayer, out Vector3 screenPoint)
+        {
+            CameraClass worldCameraInstance = CameraClass.Instance;
+            Camera worldCamera = worldCameraInstance.Camera;
+
+            screenPoint = Vector3.zero;
+
+            if (mainPlayer == null || worldCamera == null)
+                return false;
+
+            ProceduralWeaponAnimation weaponAnimation = mainPlayer.ProceduralWeaponAnimation;
+
+            if (weaponAnimation != null)
+            {
+                if (weaponAnimation.IsAiming && weaponAnimation.CurrentScope.IsOptic)
+                {
+                    Camera opticCamera = worldCameraInstance.OpticCameraManager.Camera;
+
+                    if (GetScopeZoomLevel(weaponAnimation) > 1f)
+                    {
+                        Vector3 opticCenterScreenPosition = GetOpticCenterScreenPosition(weaponAnimation, worldCamera);
+                        Vector3 opticCenterScreenOffset = opticCenterScreenPosition - (new Vector3(Screen.width, Screen.height, 0f) / 2);
+
+                        float opticScale = (Screen.height / opticCamera.scaledPixelHeight);
+                        Vector3 opticCameraOffset = new Vector3(x: (worldCamera.pixelWidth / 2 - opticCamera.pixelWidth / 2), y: (worldCamera.pixelHeight / 2 - opticCamera.pixelHeight / 2), z: 0);
+                        Vector3 opticScreenPoint = (opticCamera.WorldToScreenPoint(worldPosition) + opticCameraOffset) * opticScale;
+
+                        if (opticScreenPoint.z > 0f)
+                            screenPoint = opticScreenPoint + opticCenterScreenOffset;
+                    }
+                }
+            }
+
+            //not able to find a zoomed optic screen point
+            if (screenPoint == Vector3.zero)
+                screenPoint = worldCamera.WorldToScreenPoint(worldPosition);
+
+            if (screenPoint.z > 0f)
+                return true;
+
+            return false;
+        }
+
+        private static float GetScopeZoomLevel(ProceduralWeaponAnimation weaponAnimation)
+        {
+            SightComponent weaponSight = weaponAnimation.CurrentAimingMod;
+
+            if (weaponSight == null)
+                return 1f;
+
+            return weaponSight.GetCurrentOpticZoom();
+        }
+
+        private static Vector3 GetOpticCenterScreenPosition(ProceduralWeaponAnimation weaponAnimation, Camera worldCamera)
+        {
+            if (weaponAnimation == null)
+                return Vector3.zero;
+
+            OpticSight currentOptic = weaponAnimation.HandsContainer.Weapon.GetComponentInChildren<OpticSight>();
+            if (currentOptic == null)
+                return Vector3.zero;
+
+            Transform lensTransform = currentOptic.LensRenderer.transform;
+            return worldCamera.WorldToScreenPoint(lensTransform.position);
+        }
+    }
+}

--- a/Fika.Core/Utils/WorldToScreen.cs
+++ b/Fika.Core/Utils/WorldToScreen.cs
@@ -16,7 +16,9 @@ namespace Fika.Core.Utils
             screenPoint = Vector3.zero;
 
             if (mainPlayer == null || worldCamera == null)
+            {
                 return false;
+            }
 
             ProceduralWeaponAnimation weaponAnimation = mainPlayer.ProceduralWeaponAnimation;
 
@@ -32,21 +34,27 @@ namespace Fika.Core.Utils
                         Vector3 opticCenterScreenOffset = opticCenterScreenPosition - (new Vector3(Screen.width, Screen.height, 0f) / 2);
 
                         float opticScale = (Screen.height / opticCamera.scaledPixelHeight);
-                        Vector3 opticCameraOffset = new Vector3(x: (worldCamera.pixelWidth / 2 - opticCamera.pixelWidth / 2), y: (worldCamera.pixelHeight / 2 - opticCamera.pixelHeight / 2), z: 0);
+                        Vector3 opticCameraOffset = new Vector3((worldCamera.pixelWidth / 2 - opticCamera.pixelWidth / 2), (worldCamera.pixelHeight / 2 - opticCamera.pixelHeight / 2), 0);
                         Vector3 opticScreenPoint = (opticCamera.WorldToScreenPoint(worldPosition) + opticCameraOffset) * opticScale;
 
                         if (opticScreenPoint.z > 0f)
+                        {
                             screenPoint = opticScreenPoint + opticCenterScreenOffset;
+                        }
                     }
                 }
             }
 
             //not able to find a zoomed optic screen point
             if (screenPoint == Vector3.zero)
+            {
                 screenPoint = worldCamera.WorldToScreenPoint(worldPosition);
+            }
 
             if (screenPoint.z > 0f)
+            {
                 return true;
+            }
 
             return false;
         }
@@ -56,7 +64,9 @@ namespace Fika.Core.Utils
             SightComponent weaponSight = weaponAnimation.CurrentAimingMod;
 
             if (weaponSight == null)
+            {
                 return 1f;
+            }
 
             return weaponSight.GetCurrentOpticZoom();
         }
@@ -64,11 +74,15 @@ namespace Fika.Core.Utils
         private static Vector3 GetOpticCenterScreenPosition(ProceduralWeaponAnimation weaponAnimation, Camera worldCamera)
         {
             if (weaponAnimation == null)
+            {
                 return Vector3.zero;
+            }
 
             OpticSight currentOptic = weaponAnimation.HandsContainer.Weapon.GetComponentInChildren<OpticSight>();
             if (currentOptic == null)
+            {
                 return Vector3.zero;
+            }
 
             Transform lensTransform = currentOptic.LensRenderer.transform;
             return worldCamera.WorldToScreenPoint(lensTransform.position);


### PR DESCRIPTION
This PR implements optic zoom WorldToScreen resolution for both pings and coop player nameplates/health. Tested with Vudu 1x/6x, Valday 1x/6x, ADO 3x/9x, and Specter 1x/4x optics. Does not change default behavior for any reflex sight or optic with zoom level <= 1.0. Did not test with SSAA, but it shouldn't affect anything as both the worldCamera and opticCamera should scale the same and the screen scale logic was not changed.