### PR TITLE
Save profile immediately upon death

### DIFF
--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -1738,7 +1738,7 @@ namespace Fika.Core.Coop.GameMode
             player.CheckAndResetControllers(exitStatus, base.PastTime, base.Location_0.Id, exitName);
 
             //Method taken directly from AKI, can be found in the aki-singleplayer assembly as OfflineSaveProfilePatch
-            var converterClass = typeof(AbstractGame).Assembly.GetTypes().First(t => t.GetField("Converters", BindingFlags.Static | BindingFlags.Public) != null);
+            Type converterClass = typeof(AbstractGame).Assembly.GetTypes().First(t => t.GetField("Converters", BindingFlags.Static | BindingFlags.Public) != null);
 
             JsonConverter[] Converters = Traverse.Create(converterClass).Field<JsonConverter[]>("Converters").Value;
 
@@ -1748,7 +1748,7 @@ namespace Fika.Core.Coop.GameMode
                 Profile = player.Profile,
                 Health = HealthListener.Instance.CurrentHealth,
                 Insurance = InsuredItemManager.Instance.GetTrackedItems(),
-                IsPlayerScav = RaidSettings.IsScav // If session joining mixed with both PMC's and scavs is added this might have to be changed
+                IsPlayerScav = player.Side is EPlayerSide.Savage
             };
 
             RequestHandler.PutJson("/raid/profile/save", SaveRequest.ToJson(Converters.AddItem(new NotesJsonConverter()).ToArray()));

--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -1516,7 +1516,10 @@ namespace Fika.Core.Coop.GameMode
 
             player.ActiveHealthController.DiedEvent -= MainPlayerDied;
 
-            SavePlayer(coopPlayer, MyExitStatus, null);
+            if(FikaPlugin.Instance.ForceSaveOnDeath)
+            {
+                SavePlayer(coopPlayer, MyExitStatus, null);
+            }
 
             if (FikaPlugin.AutoExtract.Value)
             {
@@ -1590,7 +1593,10 @@ namespace Fika.Core.Coop.GameMode
             MyExitStatus = ExitStatus.Killed;
             MyExitLocation = null;
 
-            SavePlayer((CoopPlayer)gparam_0.Player, MyExitStatus, null);
+            if(FikaPlugin.Instance.ForceSaveOnDeath)
+            {
+                SavePlayer((CoopPlayer)gparam_0.Player, MyExitStatus, null);
+            }
         }
 
         public override void Stop(string profileId, ExitStatus exitStatus, string exitName, float delay = 0f)

--- a/Fika.Core/Coop/Players/CoopPlayer.cs
+++ b/Fika.Core/Coop/Players/CoopPlayer.cs
@@ -1339,6 +1339,15 @@ namespace Fika.Core.Coop.Players
             }
         }
 
+        public void CheckAndResetControllers(ExitStatus exitStatus, float pastTime, string locationId, string exitName)
+        {
+            _questController?.CheckExitConditionCounters(exitStatus, pastTime, locationId, exitName, HealthController.BodyPartEffects, TriggerZones);
+            _questController?.ResetCurrentNullableCounters();
+
+            _achievementsController?.CheckExitConditionCounters(exitStatus, pastTime, locationId, exitName, HealthController.BodyPartEffects, TriggerZones);
+            _achievementsController?.ResetCurrentNullableCounters();
+        }
+
         public virtual void SetInventory(EquipmentClass equipmentClass)
         {
             // Do nothing

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -180,6 +180,7 @@ namespace Fika.Core
         public bool DynamicVExfils;
         public bool AllowFreeCam;
         public bool AllowItemSending;
+        public bool ForceSaveOnDeath;
         #endregion
 
         protected void Awake()
@@ -228,6 +229,11 @@ namespace Fika.Core
                 new ItemContext_Patch().Enable();
             }
 
+            if(ForceSaveOnDeath)
+            {
+                new OfflineSaveProfilePatch().Disable(); //Disable this as we've moved it forward immediately after extraction or death
+            }
+
             BotDifficulties = FikaRequestHandler.GetBotDifficulties();
             ConsoleScreen.Processor.RegisterCommandGroup<FikaCommands>();
 
@@ -258,6 +264,7 @@ namespace Fika.Core
             DynamicVExfils = clientConfig.DynamicVExfils;
             AllowFreeCam = clientConfig.AllowFreeCam;
             AllowItemSending = clientConfig.AllowItemSending;
+            ForceSaveOnDeath = clientConfig.ForceSaveOnDeath;
 
             clientConfig.ToString();
         }

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -453,6 +453,7 @@ namespace Fika.Core
             new BTRInteractionPatch().Disable();
             new BTRExtractPassengersPatch().Disable();
             new BTRPatch().Disable();
+            new OfflineSaveProfilePatch().Disable(); //Disable this as we've moved it forward immediately after extraction or death
         }
 
         private void EnableOverridePatches()

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -460,7 +460,6 @@ namespace Fika.Core
             new BTRInteractionPatch().Disable();
             new BTRExtractPassengersPatch().Disable();
             new BTRPatch().Disable();
-            new OfflineSaveProfilePatch().Disable(); //Disable this as we've moved it forward immediately after extraction or death
         }
 
         private void EnableOverridePatches()

--- a/Fika.Core/Models/ClientConfigModel.cs
+++ b/Fika.Core/Models/ClientConfigModel.cs
@@ -21,13 +21,17 @@ namespace Fika.Core.UI.Models
         [DataMember(Name = "allowItemSending")]
         public bool AllowItemSending;
 
-        public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowItemSending)
+        [DataMember(Name = "forceSaveOnDeath")]
+        public bool ForceSaveOnDeath;
+
+        public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowItemSending, bool forceSaveOnDeath)
         {
             UseBTR = useBTR;
             FriendlyFire = friendlyFire;
             DynamicVExfils = dynamicVExfils;
             AllowFreeCam = allowFreeCam;
             AllowItemSending = allowItemSending;
+            ForceSaveOnDeath = forceSaveOnDeath;
         }
 
         public new void ToString()


### PR DESCRIPTION
This adds some part of an initial anti alt-f4 implementation, I think it can get more fleshed out once reconnecting is added as there's no way to currently tell if a disconnection is on purpose or if the client just dropped out due to a bad internet or a game crash.

Eventually, maybe letting the host handle saving the profiles of clients might also be a good alternative.. But I'm not sure as to how feasible that is in the current system.