### PR TITLE
Allow examination of items in raid

### DIFF
--- a/Fika.Core/Coop/Players/CoopPlayer.cs
+++ b/Fika.Core/Coop/Players/CoopPlayer.cs
@@ -62,7 +62,7 @@ namespace Fika.Core.Coop.Players
             player.IsYourPlayer = true;
             player.NetId = netId;
 
-            CoopClientInventoryController inventoryController = new(player, profile, true);
+            CoopClientInventoryController inventoryController = new(player, profile, false);
 
             ISession session = Singleton<ClientApplication<ISession>>.Instance.GetClientBackEndSession();
 


### PR DESCRIPTION
This change makes it so that items have to be examined in raid, the reason for this is that sometimes as a Scav you can find things like body armor or a backpack that are not yet examined. However then when you go out of raid you cannot take these into your inventory as you cannot examine them forcing you to sell to fence.