### PR TITLE
Added the mod verification logic

### DIFF
--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -246,7 +246,7 @@ namespace Fika.Core
         private IEnumerator RunModHandler()
         {
             yield return new WaitForSeconds(5);
-            ModHandler.Run();
+            ModHandler.VerifyMods();
         }
 
         private void GetClientConfig()

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -46,7 +46,7 @@ namespace Fika.Core
     /// Originally by: Paulov <br/>
     /// Re-written by: Lacyway
     /// </summary>
-    [BepInPlugin("com.project-fika.core", "Fika.Core", "0.9.8906")]
+    [BepInPlugin("com.fika.core", "Fika.Core", "0.9.8906")]
     [BepInProcess("EscapeFromTarkov.exe")]
     [BepInDependency("com.SPT.custom", BepInDependency.DependencyFlags.HardDependency)] // This is used so that we guarantee to load after aki-custom, that way we can disable its patches
     [BepInDependency("com.SPT.singleplayer", BepInDependency.DependencyFlags.HardDependency)] // This is used so that we guarantee to load after aki-singleplayer, that way we can disable its patches

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -46,7 +46,7 @@ namespace Fika.Core
     /// Originally by: Paulov <br/>
     /// Re-written by: Lacyway
     /// </summary>
-    [BepInPlugin("com.fika.core", "Fika.Core", "0.9.8906")]
+    [BepInPlugin("com.project-fika.core", "Fika.Core", "0.9.8906")]
     [BepInProcess("EscapeFromTarkov.exe")]
     [BepInDependency("com.SPT.custom", BepInDependency.DependencyFlags.HardDependency)] // This is used so that we guarantee to load after aki-custom, that way we can disable its patches
     [BepInDependency("com.SPT.singleplayer", BepInDependency.DependencyFlags.HardDependency)] // This is used so that we guarantee to load after aki-singleplayer, that way we can disable its patches

--- a/Fika.Core/Networking/Models/ModValidationResponse.cs
+++ b/Fika.Core/Networking/Models/ModValidationResponse.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Serialization;
+
+namespace Fika.Core.Networking.Http.Models
+{
+    [DataContract]
+    public struct ModValidationResponse
+    {
+        [DataMember(Name = "forbidden")]
+        public string[] Forbidden;
+
+        [DataMember(Name = "missingRequired")]
+        public string[] MissingRequired;
+
+        [DataMember(Name = "hashMismatch")]
+        public string[] HashMismatch;
+    }
+}

--- a/Fika.Core/Utils/FikaModHandler.cs
+++ b/Fika.Core/Utils/FikaModHandler.cs
@@ -36,6 +36,7 @@ namespace Fika.Core.Utils
                 byte[] fileBytes = File.ReadAllBytes(location);
                 uint crc32 = CRC32C.Compute(fileBytes, 0, fileBytes.Length);
                 loadedMods.Add(pluginInfo.Metadata.GUID, crc32);
+                logger.LogInfo($"Loaded plugin: [{pluginInfo.Metadata.Name}] with GUID [{pluginInfo.Metadata.GUID}] and crc32 [{crc32}]");
                 CheckSpecialMods(pluginInfo.Metadata.GUID);
             }
 

--- a/Fika.Core/Utils/FikaModHandler.cs
+++ b/Fika.Core/Utils/FikaModHandler.cs
@@ -1,70 +1,110 @@
 ﻿using BepInEx;
 using BepInEx.Bootstrap;
 using BepInEx.Logging;
-using Fika.Core.Networking.Models;
+using Comfort.Common;
+using EFT;
+using EFT.UI;
+using Fika.Core.Networking.Http.Models;
 using LiteNetLib.Utils;
+using Newtonsoft.Json;
+using SPT.Common.Http;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using UnityEngine;
+using Logger = BepInEx.Logging.Logger;
 
 namespace Fika.Core.Utils
 {
     public class FikaModHandler
     {
-        private string[] loadedMods;
         private readonly ManualLogSource logger = Logger.CreateLogSource("FikaModHandler");
 
         public bool QuestingBotsLoaded = false;
         public bool SAINLoaded = false;
 
-        public void Run()
-        {
-            // Store all loaded plugins (mods) to improve compatibility
-            List<string> tempPluginInfos = [];
-
-            foreach (string key in Chainloader.PluginInfos.Keys)
-            {
-                logger.LogInfo($"Adding {key}, {Chainloader.PluginInfos[key].Metadata.Name} to loaded mods.");
-                tempPluginInfos.Add(key);
-                CheckSpecialMods(key);
-            }
-
-            /*if (FikaPlugin.Instance.RequiredMods.Count > 0)
-            {
-                VerifyMods();
-            }*/
-
-            loadedMods = [.. tempPluginInfos];
-
-            logger.LogInfo($"Loaded {loadedMods.Length} mods!");
-        }
-
-        private void VerifyMods()
+        public void VerifyMods()
         {
             PluginInfo[] pluginInfos = [.. Chainloader.PluginInfos.Values];
-            Dictionary<string, string> loadedMods = [];
+
+            // Set capacity to avoid unnecessarily resizing for people who have a lot of mods loaded
+            Dictionary<string, uint> loadedMods = new Dictionary<string, uint>(pluginInfos.Length);
 
             foreach (PluginInfo pluginInfo in pluginInfos)
             {
                 string location = pluginInfo.Location;
                 byte[] fileBytes = File.ReadAllBytes(location);
                 uint crc32 = CRC32C.Compute(fileBytes, 0, fileBytes.Length);
-                loadedMods.Add(pluginInfo.Metadata.GUID, crc32.ToString());
+                loadedMods.Add(pluginInfo.Metadata.GUID, crc32);
+                CheckSpecialMods(pluginInfo.Metadata.GUID);
             }
 
-            ModValidationRequest modValidationRequest = new(loadedMods);
-            // Send
+            string modValidationRequestJson = JsonConvert.SerializeObject(loadedMods);
+            logger.LogDebug(modValidationRequestJson);
+
+            string validationJson = RequestHandler.PostJson("/fika/client/check/mods", modValidationRequestJson);
+            logger.LogDebug(validationJson);
+
+            ModValidationResponse validationResult = 
+                JsonConvert.DeserializeObject<ModValidationResponse>(validationJson);
+
+            // If any errors were detected we will print what has happened
+            bool installationError =
+                validationResult.Forbidden.Length > 0 ||
+                validationResult.MissingRequired.Length > 0 ||
+                validationResult.HashMismatch.Length > 0;
+
+            if (validationResult.Forbidden.Length > 0)
+            {
+                logger.LogError($"{validationResult.Forbidden.Length} forbidden mod(s) are loaded, have the server host allow or remove the following mods: {string.Join(", ", validationResult.Forbidden)}");
+            }
+
+            if (validationResult.MissingRequired.Length > 0)
+            {
+                logger.LogError($"{validationResult.MissingRequired.Length} missing required mod(s), verify the following mods are present: {string.Join(", ", validationResult.MissingRequired)}");
+            }
+
+            if (validationResult.HashMismatch.Length > 0)
+            {
+                logger.LogWarning($"{validationResult.HashMismatch.Length} mismatched mod(s) are loaded, verify the following mods are up to date with the server host: {string.Join(", ", validationResult.HashMismatch)}");
+            }
+
+            if (installationError)
+            {
+                StaticManager.BeginCoroutine(InformInstallationError());
+            }
+        }
+
+        private IEnumerator InformInstallationError()
+        {
+            while (!Singleton<PreloaderUI>.Instantiated)
+            {
+                yield return null;
+            }
+
+            string message = "Your client doesn't meet server requirements, check logs for more details";
+
+            // -1f time makes the message permanent
+            Singleton<PreloaderUI>.Instance.ShowCriticalErrorScreen("INSTALLATION ERROR", message,
+                ErrorScreen.EButtonType.QuitButton, -1f, Application.Quit, null);
         }
 
         private void CheckSpecialMods(string key)
         {
-            if (key == "com.DanW.QuestingBots")
+            switch (key)
             {
-                QuestingBotsLoaded = true;
-            }
+                case "com.DanW.QuestingBots":
+                    {
+                        QuestingBotsLoaded = true;
 
-            if (key == "me.sol.sain")
-            {
-                SAINLoaded = true;
+                        break;
+                    }
+                case "me.sol.sain":
+                    {
+                        SAINLoaded = true;
+
+                        break;
+                    }
             }
         }
     }


### PR DESCRIPTION
In this PR I changed the BepInPlugin ID for FikaPlugin from "com.fika.core" to "com.project-fika.core". Any mods that required the ID to mark their plugin as required/incompatible will need to be updated to reflect this.

This notation is known as a "package" or "namespace". Typically the makeup is tld.domain.packagename. This is used to link back to the source. Typically developers who do not own a domain would use me.nexus4880.packagename though we own the domain project-fika.com, therefore we should be using that.

This wouldn't normally be something I'd even bring up though at the time of writing this fika.com is a registered domain and in my opinion we shouldn't attribute this package to them as they are not affiliated with this project.