### PR TITLE
Fix CounterCreator quest progression

### DIFF
--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -512,11 +512,11 @@ namespace Fika.Core
         public enum EQuestSharingTypes
         {
             Kill = 1,
-            Hit = 2,
+            Item = 2,
             Location = 4,
             PlaceBeacon = 8,
 
-            All = Kill | Hit | Location | PlaceBeacon
+            All = Kill | Item | Location | PlaceBeacon
         }
     }
 }


### PR DESCRIPTION
Since the type of quest is not given with counter.Type when the quest objective has multiple tasks (CounterCreator) make it possible for it to be checked.

This also modifies it so the initialization is a switch statement, as CounterCreator has a lot of conditions available and I feel that it's best to keep it in the current format (Kill, Item, Location etc) as well as turning 'Hit' into 'Item'