### PR TITLE
Check if quest item is Active and Enabled

### DIFF
--- a/Fika.Core/Coop/Players/CoopPlayer.cs
+++ b/Fika.Core/Coop/Players/CoopPlayer.cs
@@ -1555,13 +1555,13 @@ namespace Fika.Core.Coop.Players
                 {
                     if (lootItem is LootItem observedLootItem)
                     {
-                        if (observedLootItem.Item.TemplateId == itemId)
+                        if (observedLootItem.Item.TemplateId == itemId && observedLootItem.isActiveAndEnabled)
                         {
                             return observedLootItem.Item;
                         }
                     }
                 }
-                FikaPlugin.Instance.FikaLogger.LogError($"CoopPlayer::FindItem: Could not find questItem with id '{itemId}' in the world at all.");
+                FikaPlugin.Instance.FikaLogger.LogInfo($"CoopPlayer::FindItem: Could not find questItem with id '{itemId}' in the current session, either the quest is not active or something else occured.");
                 return null;
             }
 


### PR DESCRIPTION
Adds a check in CoopPlayer to check if the quest item is active and enabled, without this check anytime a user that still needs to do a quest it also gets replicated to users that have already done the quest causing them to get a useless quest item in their quest inventory (And in some cases causing the quest to be ready to be completed again)