### PR TITLE
Added check to see if an error was returned while attempting to downl…

### DIFF
--- a/Fika.Core/UI/Patches/MenuTaskBar_Patch.cs
+++ b/Fika.Core/UI/Patches/MenuTaskBar_Patch.cs
@@ -63,8 +63,9 @@ namespace Fika.Core.UI.Patches
                             try
                             {
                                 JObject profile = await FikaRequestHandler.GetProfile();
-
-                                if (profile != null)
+                                bool responseHasError = profile.ContainsKey("errmsg");
+                                string error = responseHasError ? profile.Value<string>("errmsg") : "Failed to retrieve profile";
+                                if (!responseHasError && profile != null)
                                 {
                                     Singleton<GUISounds>.Instance.PlayUISound(EUISoundType.ButtonBottomBarClick);
                                     string installDir = Environment.CurrentDirectory;
@@ -92,7 +93,7 @@ namespace Fika.Core.UI.Patches
                                 }
                                 else
                                 {
-                                    NotificationManagerClass.DisplayWarningNotification("Failed to retrieve profile");
+                                    NotificationManagerClass.DisplayWarningNotification(error);
                                 }
                             }
                             catch (Exception ex)


### PR DESCRIPTION
…oad profile. If the server was unable to handle the request (meaning the server mod is not up to date) then the client would continue assuming the following is their profile:
```
{
  "err": 404,
  "errmsg": "UNHANDLED RESPONSE: /fika/profile/download"
}
```
This commit checks to see if the errmsg property exists.