### PR TITLE
Handle setting correct id on initialization of AirdropBox

### DIFF
--- a/Fika.Core/Coop/Airdrops/FikaAirdropsManager.cs
+++ b/Fika.Core/Coop/Airdrops/FikaAirdropsManager.cs
@@ -113,6 +113,7 @@ namespace Coop.Airdrops
                     AirdropParameters.DropHeight, AirdropParameters.Config.PlaneVolume,
                     AirdropParameters.Config.PlaneSpeed);
                 AirdropBox = await AirdropBox.Init(AirdropParameters.Config.CrateFallSpeed);
+                AirdropBox.container.Id = "FikaAirdropContainer";
                 factory = new FikaItemFactoryUtil();
             }
             catch


### PR DESCRIPTION
Throws error on clients otherwise, probably a good idea to keep this set anyway.