### PR TITLE
(HEADLESS CLIENT) add support for the `-nographics` paremeter

### DIFF
--- a/Fika.Dedicated/FikaDedicatedPlugin.cs
+++ b/Fika.Dedicated/FikaDedicatedPlugin.cs
@@ -53,6 +53,9 @@ namespace Fika.Headless
             new SessionResultExitStatusPatch().Enable();
             new MenuScreenPatch().Enable();
             new HealthTreamentScreenPatch().Enable();
+            new ValidateFormatPatch1().Enable();
+            new ValidateFormatPatch2().Enable();
+            new ValidateFormatPatch3().Enable();
             //InvokeRepeating("ClearRenderables", 1f, 1f);
         }
 

--- a/Fika.Dedicated/Patches/TextureValidateFormatPatch1.cs
+++ b/Fika.Dedicated/Patches/TextureValidateFormatPatch1.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Aki.Reflection.Patching;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+
+namespace Fika.Headless.Patches {
+    // https://github.com/Unity-Technologies/UnityCsReference/blob/77b37cd9f002e27b45be07d6e3667ee53985ec82/Runtime/Export/Graphics/Texture.cs#L696
+    public class ValidateFormatPatch1 : ModulePatch {
+        protected override MethodBase GetTargetMethod()
+        {
+            var methods = typeof(Texture).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance);
+
+            foreach (var method in methods)
+            {
+                if (method.Name == "ValidateFormat" && method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(RenderTextureFormat))
+                {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+
+        [PatchPostfix]
+        static void Postfix(ref bool __result)
+        {
+            __result = true;
+        }
+    }
+}

--- a/Fika.Dedicated/Patches/TextureValidateFormatPatch2.cs
+++ b/Fika.Dedicated/Patches/TextureValidateFormatPatch2.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Aki.Reflection.Patching;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+
+namespace Fika.Headless.Patches {
+    // https://github.com/Unity-Technologies/UnityCsReference/blob/77b37cd9f002e27b45be07d6e3667ee53985ec82/Runtime/Export/Graphics/Texture.cs#L709
+    public class ValidateFormatPatch2 : ModulePatch 
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var methods = typeof(Texture).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance);
+
+            foreach (var method in methods)
+            {
+                if (method.Name == "ValidateFormat" && method.GetParameters().Length == 1 && method.GetParameters()[0].ParameterType == typeof(TextureFormat))
+                {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+
+        [PatchPostfix]
+        static void Postfix(ref bool __result)
+        {
+            Logger.LogError($"ValidateFormat: {__result}");
+            __result = true;
+        }
+    }
+}

--- a/Fika.Dedicated/Patches/TextureValidateFormatPatch2.cs
+++ b/Fika.Dedicated/Patches/TextureValidateFormatPatch2.cs
@@ -25,7 +25,6 @@ namespace Fika.Headless.Patches {
         [PatchPostfix]
         static void Postfix(ref bool __result)
         {
-            Logger.LogError($"ValidateFormat: {__result}");
             __result = true;
         }
     }

--- a/Fika.Dedicated/Patches/TextureValidateFormatPatch3.cs
+++ b/Fika.Dedicated/Patches/TextureValidateFormatPatch3.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using Aki.Reflection.Patching;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+
+namespace Fika.Headless.Patches {
+    // https://github.com/Unity-Technologies/UnityCsReference/blob/77b37cd9f002e27b45be07d6e3667ee53985ec82/Runtime/Export/Graphics/Texture.cs#L730
+    public class ValidateFormatPatch3 : ModulePatch 
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var methods = typeof(Texture).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance);
+
+            foreach (var method in methods)
+            {
+                if (method.Name == "ValidateFormat" && method.GetParameters().Length == 2 && method.GetParameters()[0].ParameterType == typeof(GraphicsFormat))
+                {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+
+        [PatchPostfix]
+        static void Postfix(ref bool __result)
+        {
+            Logger.LogError($"ValidateFormat: {__result}");
+            __result = true;
+        }
+    }
+}

--- a/Fika.Dedicated/Patches/TextureValidateFormatPatch3.cs
+++ b/Fika.Dedicated/Patches/TextureValidateFormatPatch3.cs
@@ -25,7 +25,6 @@ namespace Fika.Headless.Patches {
         [PatchPostfix]
         static void Postfix(ref bool __result)
         {
-            Logger.LogError($"ValidateFormat: {__result}");
             __result = true;
         }
     }


### PR DESCRIPTION
This PR adds support for the unity parameter `-nographics`

Before marking this as ready i want to test some map (without and with the parameter) as a benchmark

performance was measured using this docker container https://github.com/zhliau/fika-headless-docker
and ``docker stats``

the values are rough average values measured during a normal raid
CPU usage was measured on a `AMD Ryzen 5 4500` (100% means 1 full core). a dedicated GPU was not installed

all of them were measured with 1 player and quite a bunch of mods installed (so dont see them as the most acurate values).

The container was also restarted after every raid.

The ram cleaner mod was also installed, but im not sure if that even works on linux.

| Map | CPU %  |  Memory GiB | CPU % (`-nographics`) | Memory (`-nographics`) |  
| ----- | -------- | ---------- | ------------------------ | -------------------------- |
| Main Menu | 23.5 | 6.912 | 24.60 | 3.611 |
| Ground Zero | 270 | 11.88 | 270 | 6.9 |
| Factory | 240 | 8.76 | 230 | 5.295 |
| Customs | 250 | 12 | 285| 7.1 |
| Streets | - | My 16 GB sys ran out of memory ): | 275 | 10.88

as im still playing on 3.8.3, i dont know when i will be able to test it for 3.9.3.