### PR TITLE
Handle AirdropManager for adding projectiles being null on headless host

### DIFF
--- a/Fika.Core/Coop/Airdrops/FikaAirdropPlane.cs
+++ b/Fika.Core/Coop/Airdrops/FikaAirdropPlane.cs
@@ -128,11 +128,11 @@ namespace Fika.Core.Coop.Airdrops
             ParticleSystem[] flares = projectile.GetComponentsInChildren<ParticleSystem>();
             float endTime = Time.unscaledTime + emissionTime;
 
-            GameWorld Gameworld = Singleton<GameWorld>.Instance;
+            GameWorld gameWorld= Singleton<GameWorld>.Instance;
 
-            if (Gameworld.SynchronizableObjectLogicProcessor.AirdropManager != null)
+            if (gameWorld.SynchronizableObjectLogicProcessor.AirdropManager != null)
             {
-                Gameworld.SynchronizableObjectLogicProcessor.AirdropManager.AddProjectile(projectile,
+                gameWorld.SynchronizableObjectLogicProcessor.AirdropManager.AddProjectile(projectile,
                 endTime + flares[0].main.duration + flares[0].main.startLifetime.Evaluate(1f));
             }
 

--- a/Fika.Core/Coop/Airdrops/FikaAirdropPlane.cs
+++ b/Fika.Core/Coop/Airdrops/FikaAirdropPlane.cs
@@ -127,8 +127,14 @@ namespace Fika.Core.Coop.Airdrops
             projectile.transform.localPosition = new Vector3(0f, -5f, 0f);
             ParticleSystem[] flares = projectile.GetComponentsInChildren<ParticleSystem>();
             float endTime = Time.unscaledTime + emissionTime;
-            Singleton<GameWorld>.Instance.SynchronizableObjectLogicProcessor.AirdropManager.AddProjectile(projectile,
+
+            GameWorld Gameworld = Singleton<GameWorld>.Instance;
+
+            if (Gameworld.SynchronizableObjectLogicProcessor.AirdropManager != null)
+            {
+                Gameworld.SynchronizableObjectLogicProcessor.AirdropManager.AddProjectile(projectile,
                 endTime + flares[0].main.duration + flares[0].main.startLifetime.Evaluate(1f));
+            }
 
             while (endTime > Time.unscaledTime)
                 yield return null;


### PR DESCRIPTION
Causes the headless host to crash if an airdrop is being dropped, handle this by checking if the manager is not null before trying to add the Projectile.