### PR TITLE
Make the debug window draggable

### DIFF
--- a/Fika.Core/Coop/Custom/FikaDebug.cs
+++ b/Fika.Core/Coop/Custom/FikaDebug.cs
@@ -145,7 +145,7 @@ namespace Fika.Core.Coop.Custom
             GUI.skin.label.alignment = TextAnchor.MiddleLeft;
             GUI.skin.window.alignment = TextAnchor.UpperCenter;
 
-            GUI.Window(0, windowRect, DrawWindow, "Fika Debug");
+            windowRect = GUI.Window(0, windowRect, DrawWindow, "Fika Debug");
         }
 
         private void DrawWindow(int windowId)
@@ -168,6 +168,7 @@ namespace Fika.Core.Coop.Custom
 
             GUILayout.EndVertical();
             GUILayout.EndArea();
+            GUI.DragWindow();
         }
     }
 }


### PR DESCRIPTION
It covers up my health in the default position. Right now it doesn't save the position or anything, I just wanted to be able to move it out of the way easily.