### PR TITLE
Allow players to ping whilst dead.

### DIFF
--- a/Fika.Core/Coop/PacketHandlers/ClientPacketSender.cs
+++ b/Fika.Core/Coop/PacketHandlers/ClientPacketSender.cs
@@ -156,7 +156,6 @@ namespace Fika.Core.Coop.PacketHandlers
             }
             if (FikaPlugin.UsePingSystem.Value
                 && player.IsYourPlayer
-                && player.HealthController.IsAlive
                 && Input.GetKey(FikaPlugin.PingButton.Value.MainKey)
                 && FikaPlugin.PingButton.Value.Modifiers.All(Input.GetKey))
             {


### PR DESCRIPTION
Remove line that checks for whether or not the player is dead before sending ping packet. Resolves medium priority roadmap item "Pinging when dead"