### PR TITLE
Disable/enable spectator freecam

### DIFF
--- a/Fika.Core/Coop/FreeCamera/FreeCamera.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCamera.cs
@@ -281,60 +281,54 @@ namespace Fika.Core.Coop.FreeCamera
 				return;
 			}
 
-            // If we are currently dead/extracted and we don't allow spectate freecam
-            // Disable this section
-            // Do we need to check that the camera is parented to something?
-            if (!IsExtractedOrDead || FikaPlugin.Instance.AllowSpectateFreeCam)
+            bool fastMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+            bool superFastMode = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+            float movementSpeed = fastMode ? 20f : 2f;
+
+            if (superFastMode)
             {
-                bool fastMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
-                bool superFastMode = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
-                float movementSpeed = fastMode ? 20f : 2f;
+                movementSpeed *= 8;
+            }
 
-                if (superFastMode)
-                {
-                    movementSpeed *= 8;
-                }
+            if (Input.GetKey(leftKey) || Input.GetKey(KeyCode.LeftArrow))
+            {
+                transform.position += -transform.right * (movementSpeed * Time.deltaTime);
+            }
 
-                if (Input.GetKey(leftKey) || Input.GetKey(KeyCode.LeftArrow))
-                {
-                    transform.position += -transform.right * (movementSpeed * Time.deltaTime);
-                }
+            if (Input.GetKey(rightKey) || Input.GetKey(KeyCode.RightArrow))
+            {
+                transform.position += transform.right * (movementSpeed * Time.deltaTime);
+            }
 
-                if (Input.GetKey(rightKey) || Input.GetKey(KeyCode.RightArrow))
-                {
-                    transform.position += transform.right * (movementSpeed * Time.deltaTime);
-                }
+            if (Input.GetKey(forwardKey) || Input.GetKey(KeyCode.UpArrow))
+            {
+                transform.position += transform.forward * (movementSpeed * Time.deltaTime);
+            }
 
-                if (Input.GetKey(forwardKey) || Input.GetKey(KeyCode.UpArrow))
-                {
-                    transform.position += transform.forward * (movementSpeed * Time.deltaTime);
-                }
+            if (Input.GetKey(backKey) || Input.GetKey(KeyCode.DownArrow))
+            {
+                transform.position += -transform.forward * (movementSpeed * Time.deltaTime);
+            }
 
-                if (Input.GetKey(backKey) || Input.GetKey(KeyCode.DownArrow))
-                {
-                    transform.position += -transform.forward * (movementSpeed * Time.deltaTime);
-                }
+            if (Input.GetKey(relUpKey))
+            {
+                transform.position += transform.up * (movementSpeed * Time.deltaTime);
+            }
 
-                if (Input.GetKey(relUpKey))
-                {
-                    transform.position += transform.up * (movementSpeed * Time.deltaTime);
-                }
+            if (Input.GetKey(relDownKey))
+            {
+                transform.position += -transform.up * (movementSpeed * Time.deltaTime);
+            }
 
-				if (Input.GetKey(relDownKey))
-				{
-					transform.position += -transform.up * (movementSpeed * Time.deltaTime);
-				}
+            if (Input.GetKey(upKey) || Input.GetKey(KeyCode.PageUp))
+            {
+                transform.position += Vector3.up * (movementSpeed * Time.deltaTime);
+            }
 
-				if (Input.GetKey(upKey) || Input.GetKey(KeyCode.PageUp))
-				{
-					transform.position += Vector3.up * (movementSpeed * Time.deltaTime);
-				}
-
-				if (Input.GetKey(downKey) || Input.GetKey(KeyCode.PageDown))
-				{
-					transform.position += -Vector3.up * (movementSpeed * Time.deltaTime);
-				}
-			}
+            if (Input.GetKey(downKey) || Input.GetKey(KeyCode.PageDown))
+            {
+                transform.position += -Vector3.up * (movementSpeed * Time.deltaTime);
+            }
 
             // Teleportation
             if (Input.GetKeyDown(KeyCode.T))

--- a/Fika.Core/Coop/FreeCamera/FreeCamera.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCamera.cs
@@ -4,6 +4,7 @@ using EFT;
 using EFT.Interactive;
 using EFT.UI;
 using Fika.Core.Coop.Components;
+using Fika.Core.Coop.GameMode;
 using Fika.Core.Coop.Players;
 using System;
 using System.Collections.Generic;
@@ -25,7 +26,7 @@ namespace Fika.Core.Coop.FreeCamera
 	{
 		public bool IsActive = false;
 		private CoopPlayer CurrentPlayer;
-		private Vector3 CurrentPlayerExfilPosition;
+		private Vector3 LastKnownPlayerPosition;
 		private bool isFollowing = false;
 		private bool leftMode = false;
 		private bool disableInput = false;
@@ -269,11 +270,7 @@ namespace Fika.Core.Coop.FreeCamera
 			{
 				if (CurrentPlayer != null)
 				{
-					if (CurrentPlayer.ExfiltrationPoint != null && CurrentPlayerExfilPosition != CurrentPlayer.ExfiltrationPoint.transform.position)
-					{
-						CurrentPlayerExfilPosition = CurrentPlayer.ExfiltrationPoint.transform.position;
-						FikaPlugin.Instance.FikaLogger.LogDebug($"Tracking currentplayer's new exfil point {CurrentPlayerExfilPosition}");
-					}
+					LastKnownPlayerPosition = CurrentPlayer.PlayerBones.Neck.position;
 					if (CurrentPlayer.MovementContext.LeftStanceEnabled && !leftMode)
 					{
 						FikaPlugin.Instance.FikaLogger.LogDebug("Setting left shoulder mode");
@@ -287,8 +284,7 @@ namespace Fika.Core.Coop.FreeCamera
 				}
 				else
 				{
-					// Find next player
-					FikaPlugin.Instance.FikaLogger.LogDebug("CurrentPlayer vanished while we were following, finding next player to attach to");
+					FikaPlugin.Instance.FikaLogger.LogDebug("Freecam: CurrentPlayer vanished while we were following, finding next player to attach to");
 					CycleSpectatePlayers();
 					if (CurrentPlayer == null)
 					{
@@ -463,10 +459,10 @@ namespace Fika.Core.Coop.FreeCamera
 
 		public void AttachToMap()
 		{
-			if (CurrentPlayerExfilPosition != null)
+			if (LastKnownPlayerPosition != null)
 			{
-				FikaPlugin.Instance.FikaLogger.LogDebug($"Attaching to last tracked exfil position {CurrentPlayerExfilPosition}");
-				transform.position = CurrentPlayerExfilPosition;
+				FikaPlugin.Instance.FikaLogger.LogDebug($"Freecam: Attaching to last tracked player position {LastKnownPlayerPosition}");
+				transform.position = LastKnownPlayerPosition;
 				return;
 			}
 		}

--- a/Fika.Core/Coop/FreeCamera/FreeCamera.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCamera.cs
@@ -11,29 +11,29 @@ using UnityEngine;
 
 namespace Fika.Core.Coop.FreeCamera
 {
-    /// <summary>
-    /// A simple free camera to be added to a Unity game object. <br/><br/>
-    /// 
-    /// Full credit to Ashley Davis on GitHub for the inital code:<br/>
-    /// https://gist.github.com/ashleydavis/f025c03a9221bc840a2b<br/><br/>
-    /// 
-    /// This is HEAVILY based on Terkoiz's work found here. Thanks for your work Terkoiz! <br/>
-    /// https://dev.sp-tarkov.com/Terkoiz/Freecam/raw/branch/master/project/Terkoiz.Freecam/FreecamController.cs
-    /// </summary>
-    public class FreeCamera : MonoBehaviour
-    {
-        public bool IsActive = false;
-        private CoopPlayer CurrentPlayer;
-        private bool isFollowing = false;
-        private bool leftMode = false;
-        private bool disableInput = false;
-        private bool showOverlay;
-        private NightVision nightVision;
-        private ThermalVision thermalVision;
-        private FreeCameraController freeCameraController;
-        private float yaw = 0f;
-        private float pitch = 0f;
-        private float lookSensitivity = 3f;
+	/// <summary>
+	/// A simple free camera to be added to a Unity game object. <br/><br/>
+	/// 
+	/// Full credit to Ashley Davis on GitHub for the inital code:<br/>
+	/// https://gist.github.com/ashleydavis/f025c03a9221bc840a2b<br/><br/>
+	/// 
+	/// This is HEAVILY based on Terkoiz's work found here. Thanks for your work Terkoiz! <br/>
+	/// https://dev.sp-tarkov.com/Terkoiz/Freecam/raw/branch/master/project/Terkoiz.Freecam/FreecamController.cs
+	/// </summary>
+	public class FreeCamera : MonoBehaviour
+	{
+		public bool IsActive = false;
+		private CoopPlayer CurrentPlayer;
+		private bool isFollowing = false;
+		private bool leftMode = false;
+		private bool disableInput = false;
+		private bool showOverlay;
+		private NightVision nightVision;
+		private ThermalVision thermalVision;
+		private FreeCameraController freeCameraController;
+		private float yaw = 0f;
+		private float pitch = 0f;
+		private float lookSensitivity = 3f;
 
 		private KeyCode forwardKey = KeyCode.W;
 		private KeyCode backKey = KeyCode.S;
@@ -71,17 +71,17 @@ namespace Fika.Core.Coop.FreeCamera
 			showOverlay = FikaPlugin.KeybindOverlay.Value;
 		}
 
-        public void SetCurrentPlayer(CoopPlayer player)
-        {
-            CurrentPlayer = player;
-            FikaPlugin.Instance.FikaLogger.LogDebug($"Freecam: Setting player to {CurrentPlayer}");
-        }
+		public void SetCurrentPlayer(CoopPlayer player)
+		{
+			CurrentPlayer = player;
+			FikaPlugin.Instance.FikaLogger.LogDebug($"Freecam: Setting player to {CurrentPlayer}");
+		}
 
-        protected void OnGUI()
-        {
-            if (IsActive && showOverlay)
-            {
-                string visionText = "Enable nightvision";
+		protected void OnGUI()
+		{
+			if (IsActive && showOverlay)
+			{
+				string visionText = "Enable nightvision";
 
 				if (nightVision != null && nightVision.On)
 				{
@@ -110,30 +110,30 @@ namespace Fika.Core.Coop.FreeCamera
 			}
 		}
 
-        public void SwitchSpectateMode()
-        {
-            bool shouldHeadCam = Input.GetKey(KeyCode.Space);
-            bool should3rdPerson = Input.GetKey(KeyCode.LeftControl);
-            if (shouldHeadCam)
-            {
-                AttachToPlayer();
-            }
-            else if (should3rdPerson)
-            {
-                Attach3rdPerson();
-            }
-            else
-            {
-                if (FikaPlugin.Instance.AllowSpectateFreeCam)
-                {
-                    JumpToPlayer();
-                }
-                else
-                {
-                    Attach3rdPerson();
-                }
-            }
-        }
+		public void SwitchSpectateMode()
+		{
+			bool shouldHeadCam = Input.GetKey(KeyCode.Space);
+			bool should3rdPerson = Input.GetKey(KeyCode.LeftControl);
+			if (shouldHeadCam)
+			{
+				AttachToPlayer();
+			}
+			else if (should3rdPerson)
+			{
+				Attach3rdPerson();
+			}
+			else
+			{
+				if (FikaPlugin.Instance.AllowSpectateFreeCam)
+				{
+					JumpToPlayer();
+				}
+				else
+				{
+					Attach3rdPerson();
+				}
+			}
+		}
 
 		/// <summary>
 		/// Helper method to cycle spectating players
@@ -281,73 +281,73 @@ namespace Fika.Core.Coop.FreeCamera
 				return;
 			}
 
-            bool fastMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
-            bool superFastMode = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
-            float movementSpeed = fastMode ? 20f : 2f;
+			bool fastMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+			bool superFastMode = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+			float movementSpeed = fastMode ? 20f : 2f;
 
-            if (superFastMode)
-            {
-                movementSpeed *= 8;
-            }
+			if (superFastMode)
+			{
+				movementSpeed *= 8;
+			}
 
-            if (Input.GetKey(leftKey) || Input.GetKey(KeyCode.LeftArrow))
-            {
-                transform.position += -transform.right * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(leftKey) || Input.GetKey(KeyCode.LeftArrow))
+			{
+				transform.position += -transform.right * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(rightKey) || Input.GetKey(KeyCode.RightArrow))
-            {
-                transform.position += transform.right * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(rightKey) || Input.GetKey(KeyCode.RightArrow))
+			{
+				transform.position += transform.right * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(forwardKey) || Input.GetKey(KeyCode.UpArrow))
-            {
-                transform.position += transform.forward * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(forwardKey) || Input.GetKey(KeyCode.UpArrow))
+			{
+				transform.position += transform.forward * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(backKey) || Input.GetKey(KeyCode.DownArrow))
-            {
-                transform.position += -transform.forward * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(backKey) || Input.GetKey(KeyCode.DownArrow))
+			{
+				transform.position += -transform.forward * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(relUpKey))
-            {
-                transform.position += transform.up * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(relUpKey))
+			{
+				transform.position += transform.up * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(relDownKey))
-            {
-                transform.position += -transform.up * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(relDownKey))
+			{
+				transform.position += -transform.up * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(upKey) || Input.GetKey(KeyCode.PageUp))
-            {
-                transform.position += Vector3.up * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(upKey) || Input.GetKey(KeyCode.PageUp))
+			{
+				transform.position += Vector3.up * (movementSpeed * Time.deltaTime);
+			}
 
-            if (Input.GetKey(downKey) || Input.GetKey(KeyCode.PageDown))
-            {
-                transform.position += -Vector3.up * (movementSpeed * Time.deltaTime);
-            }
+			if (Input.GetKey(downKey) || Input.GetKey(KeyCode.PageDown))
+			{
+				transform.position += -Vector3.up * (movementSpeed * Time.deltaTime);
+			}
 
-            // Teleportation
-            if (Input.GetKeyDown(KeyCode.T))
-            {
-                if (!CoopHandler.TryGetCoopHandler(out CoopHandler coopHandler))
-                {
-                    return;
-                }
+			// Teleportation
+			if (Input.GetKeyDown(KeyCode.T))
+			{
+				if (!CoopHandler.TryGetCoopHandler(out CoopHandler coopHandler))
+				{
+					return;
+				}
 
-                Player player = Singleton<GameWorld>.Instance.MainPlayer;
+				Player player = Singleton<GameWorld>.Instance.MainPlayer;
 
-                if (!coopHandler.ExtractedPlayers.Contains(((CoopPlayer)player).NetId) && player.HealthController.IsAlive)
-                {
-                    player?.Teleport(transform.position);
-                }
-            }
+				if (!coopHandler.ExtractedPlayers.Contains(((CoopPlayer)player).NetId) && player.HealthController.IsAlive)
+				{
+					player?.Teleport(transform.position);
+				}
+			}
 
-            float x = Input.GetAxis("Mouse X");
-            float y = Input.GetAxis("Mouse Y");
+			float x = Input.GetAxis("Mouse X");
+			float y = Input.GetAxis("Mouse Y");
 
 			pitch += y * lookSensitivity;
 			pitch = Mathf.Clamp(pitch, -89, 89);

--- a/Fika.Core/Coop/FreeCamera/FreeCamera.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCamera.cs
@@ -11,29 +11,29 @@ using UnityEngine;
 
 namespace Fika.Core.Coop.FreeCamera
 {
-	/// <summary>
-	/// A simple free camera to be added to a Unity game object. <br/><br/>
-	/// 
-	/// Full credit to Ashley Davis on GitHub for the inital code:<br/>
-	/// https://gist.github.com/ashleydavis/f025c03a9221bc840a2b<br/><br/>
-	/// 
-	/// This is HEAVILY based on Terkoiz's work found here. Thanks for your work Terkoiz! <br/>
-	/// https://dev.sp-tarkov.com/Terkoiz/Freecam/raw/branch/master/project/Terkoiz.Freecam/FreecamController.cs
-	/// </summary>
-	public class FreeCamera : MonoBehaviour
-	{
-		public bool IsActive = false;
-		private CoopPlayer CurrentPlayer;
-		private bool isFollowing = false;
-		private bool leftMode = false;
-		private bool disableInput = false;
-		private bool showOverlay;
-		private NightVision nightVision;
-		private ThermalVision thermalVision;
-		private FreeCameraController freeCameraController;
-		private float yaw = 0f;
-		private float pitch = 0f;
-		private float lookSensitivity = 3f;
+    /// <summary>
+    /// A simple free camera to be added to a Unity game object. <br/><br/>
+    /// 
+    /// Full credit to Ashley Davis on GitHub for the inital code:<br/>
+    /// https://gist.github.com/ashleydavis/f025c03a9221bc840a2b<br/><br/>
+    /// 
+    /// This is HEAVILY based on Terkoiz's work found here. Thanks for your work Terkoiz! <br/>
+    /// https://dev.sp-tarkov.com/Terkoiz/Freecam/raw/branch/master/project/Terkoiz.Freecam/FreecamController.cs
+    /// </summary>
+    public class FreeCamera : MonoBehaviour
+    {
+        public bool IsActive = false;
+        private CoopPlayer CurrentPlayer;
+        private bool isFollowing = false;
+        private bool leftMode = false;
+        private bool disableInput = false;
+        private bool showOverlay;
+        private NightVision nightVision;
+        private ThermalVision thermalVision;
+        private FreeCameraController freeCameraController;
+        private float yaw = 0f;
+        private float pitch = 0f;
+        private float lookSensitivity = 3f;
 
 		private KeyCode forwardKey = KeyCode.W;
 		private KeyCode backKey = KeyCode.S;

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -133,18 +133,18 @@ namespace Fika.Core.Coop.FreeCamera
 
 			CoopHandler.EQuitState quitState = coopHandler.GetQuitState();
 
-            if (extracted && !freeCamScript.IsActive)
-            {
-                ToggleUi();
-                if (FikaPlugin.Instance.AllowSpectateFreeCam)
-                {
-                    ToggleCamera();
-                }
-                else
-                {
-                    ToggleSpectateCamera();
-                }
-            }
+			if (extracted && !freeCamScript.IsActive)
+			{
+				ToggleUi();
+				if (FikaPlugin.Instance.AllowSpectateFreeCam)
+				{
+					ToggleCamera();
+				}
+				else
+				{
+					ToggleSpectateCamera();
+				}
+			}
 
 			if (FikaPlugin.FreeCamButton.Value.IsDown())
 			{
@@ -170,18 +170,18 @@ namespace Fika.Core.Coop.FreeCamera
 					ShowExtractMessage();
 				}
 
-                if (!freeCamScript.IsActive)
-                {
-                    ToggleUi();
-                    if (FikaPlugin.Instance.AllowSpectateFreeCam)
-                    {
-                        ToggleCamera();
-                    }
-                    else
-                    {
-                        ToggleSpectateCamera();
-                    }
-                }
+				if (!freeCamScript.IsActive)
+				{
+					ToggleUi();
+					if (FikaPlugin.Instance.AllowSpectateFreeCam)
+					{
+						ToggleCamera();
+					}
+					else
+					{
+						ToggleSpectateCamera();
+					}
+				}
 
 				if (!effectsCleared)
 				{
@@ -220,23 +220,23 @@ namespace Fika.Core.Coop.FreeCamera
 				cameraClassInstance.Camera.fieldOfView = Singleton<SharedGameSettingsClass>.Instance.Game.Settings.FieldOfView;
 			}
 
-            // Disable the DeathFade effect & Toggle the Camera
-            deathFade.DisableEffect();
-            if (!freeCamScript.IsActive)
-            {
-                ToggleUi();
-                if (FikaPlugin.Instance.AllowSpectateFreeCam)
-                {
-                    ToggleCamera();
-                }
-                else
-                {
-                    ToggleSpectateCamera();
-                }
-            }
-            ShowExtractMessage();
+			// Disable the DeathFade effect & Toggle the Camera
+			deathFade.DisableEffect();
+			if (!freeCamScript.IsActive)
+			{
+				ToggleUi();
+				if (FikaPlugin.Instance.AllowSpectateFreeCam)
+				{
+					ToggleCamera();
+				}
+				else
+				{
+					ToggleSpectateCamera();
+				}
+			}
+			ShowExtractMessage();
 
-            if (!effectsCleared)
+			if (!effectsCleared)
 			{
 				if (player != null)
 				{
@@ -334,60 +334,60 @@ namespace Fika.Core.Coop.FreeCamera
 				return;
 			}
 
-            if (!freeCamScript.IsActive)
-            {
-                SetPlayerToFreecamMode(player);
-            }
-            else
-            {
-                SetPlayerToFirstPersonMode(player);
-            }
-        }
+			if (!freeCamScript.IsActive)
+			{
+				SetPlayerToFreecamMode(player);
+			}
+			else
+			{
+				SetPlayerToFirstPersonMode(player);
+			}
+		}
 
-        public void ToggleSpectateCamera()
-        {
-            if (player == null)
-            {
-                return;
-            }
-            if (!freeCamScript.IsActive)
-            {
-                if (CoopHandler.TryGetCoopHandler(out CoopHandler coopHandler))
-                {
-                    foreach (CoopPlayer coopPlayer in coopHandler.HumanPlayers)
-                    {
-                        if (coopPlayer.HealthController.IsAlive && !coopPlayer.IsYourPlayer)
-                        {
-                            freeCamScript.SetCurrentPlayer(coopPlayer);
-                            FikaPlugin.Instance.FikaLogger.LogInfo("FreecamController: New player: " + coopPlayer.Profile.Info.MainProfileNickname);
+		public void ToggleSpectateCamera()
+		{
+			if (player == null)
+			{
+				return;
+			}
+			if (!freeCamScript.IsActive)
+			{
+				if (CoopHandler.TryGetCoopHandler(out CoopHandler coopHandler))
+				{
+					foreach (CoopPlayer coopPlayer in coopHandler.HumanPlayers)
+					{
+						if (coopPlayer.HealthController.IsAlive && !coopPlayer.IsYourPlayer)
+						{
+							freeCamScript.SetCurrentPlayer(coopPlayer);
+							FikaPlugin.Instance.FikaLogger.LogInfo("FreecamController: New player: " + coopPlayer.Profile.Info.MainProfileNickname);
 
-                            player.PointOfView = EPointOfView.ThirdPerson;
-                            if (player.PlayerBody != null)
-                            {
-                                player.PlayerBody.PointOfView.Value = EPointOfView.FreeCamera;
-                                player.GetComponent<PlayerCameraController>().UpdatePointOfView();
-                            }
-                            gamePlayerOwner.enabled = false;
-                            freeCamScript.SetActive(true);
+							player.PointOfView = EPointOfView.ThirdPerson;
+							if (player.PlayerBody != null)
+							{
+								player.PlayerBody.PointOfView.Value = EPointOfView.FreeCamera;
+								player.GetComponent<PlayerCameraController>().UpdatePointOfView();
+							}
+							gamePlayerOwner.enabled = false;
+							freeCamScript.SetActive(true);
 
-                            freeCamScript.Attach3rdPerson();
-                            return;
-                        }
-                    }
-                }
-            }
-        }
+							freeCamScript.Attach3rdPerson();
+							return;
+						}
+					}
+				}
+			}
+		}
 
-        /// <summary>
-        /// Hides the main UI (health, stamina, stance, hotbar, etc.)
-        /// </summary>
-        private void ToggleUi()
-        {
-            // Check if we're currently in a raid
-            if (player == null)
-            {
-                return;
-            }
+		/// <summary>
+		/// Hides the main UI (health, stamina, stance, hotbar, etc.)
+		/// </summary>
+		private void ToggleUi()
+		{
+			// Check if we're currently in a raid
+			if (player == null)
+			{
+				return;
+			}
 
 			// If we don't have the UI Component cached, go look for it in the scene
 			if (playerUi == null)

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -225,7 +225,6 @@ namespace Fika.Core.Coop.FreeCamera
             if (!freeCamScript.IsActive)
             {
                 ToggleUi();
-                freeCamScript.IsExtractedOrDead = true;
                 if (FikaPlugin.Instance.AllowSpectateFreeCam)
                 {
                     ToggleCamera();

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -181,6 +181,7 @@ namespace Fika.Core.Coop.FreeCamera
 					ToggleUi();
 					if (FikaPlugin.Instance.AllowSpectateFreeCam)
 					{
+						freeCamScript.transform.position = LastKnownPosition;
 						ToggleCamera();
 					}
 					else

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -374,6 +374,8 @@ namespace Fika.Core.Coop.FreeCamera
 							return;
 						}
 					}
+					// If we got here, it means there were no players to attach to at this time, so let's fallback to freecam
+					ToggleCamera();
 				}
 			}
 		}

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -214,7 +214,7 @@ namespace Fika.Core.Coop.FreeCamera
 			}
 			ShowExtractMessage();
 
-			if (!effectsCleared)
+            if (!effectsCleared)
 			{
 				if (player != null)
 				{
@@ -312,15 +312,31 @@ namespace Fika.Core.Coop.FreeCamera
 				return;
 			}
 
-			if (!freeCamScript.IsActive)
-			{
-				SetPlayerToFreecamMode(player);
-			}
-			else
-			{
-				SetPlayerToFirstPersonMode(player);
-			}
-		}
+            if (!freeCamScript.IsActive)
+            {
+                SetPlayerToFreecamMode(player);
+                if (!FikaPlugin.Instance.AllowSpectateFreeCam)
+                {
+                    if (CoopHandler.TryGetCoopHandler(out CoopHandler coopHandler))
+                    {
+                        foreach (CoopPlayer player in coopHandler.HumanPlayers)
+                        {
+                            if (player.HealthController.IsAlive && !player.IsYourPlayer)
+                            {
+                                freeCamScript.SetCurrentPlayer(player);
+                                FikaPlugin.Instance.FikaLogger.LogInfo("FreecamController: New player: " + player.Profile.Info.MainProfileNickname);
+                                freeCamScript.Attach3rdPerson();
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                SetPlayerToFirstPersonMode(player);
+            }
+        }
 
 		/// <summary>
 		/// Hides the main UI (health, stamina, stance, hotbar, etc.)

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -354,28 +354,28 @@ namespace Fika.Core.Coop.FreeCamera
 			{
 				if (CoopHandler.TryGetCoopHandler(out CoopHandler coopHandler))
 				{
-					foreach (CoopPlayer coopPlayer in coopHandler.HumanPlayers)
+					List<CoopPlayer> alivePlayers = [.. coopHandler.HumanPlayers.Where(x => !x.IsYourPlayer && x.HealthController.IsAlive)];
+					if (alivePlayers.Count <= 0)
 					{
-						if (coopPlayer.HealthController.IsAlive && !coopPlayer.IsYourPlayer)
-						{
-							freeCamScript.SetCurrentPlayer(coopPlayer);
-							FikaPlugin.Instance.FikaLogger.LogInfo("FreecamController: New player: " + coopPlayer.Profile.Info.MainProfileNickname);
-
-							player.PointOfView = EPointOfView.ThirdPerson;
-							if (player.PlayerBody != null)
-							{
-								player.PlayerBody.PointOfView.Value = EPointOfView.FreeCamera;
-								player.GetComponent<PlayerCameraController>().UpdatePointOfView();
-							}
-							gamePlayerOwner.enabled = false;
-							freeCamScript.SetActive(true);
-
-							freeCamScript.Attach3rdPerson();
-							return;
-						}
+						// No alive players to attach to at this time, so let's fallback to freecam
+						ToggleCamera();
+						return;
 					}
-					// If we got here, it means there were no players to attach to at this time, so let's fallback to freecam
-					ToggleCamera();
+					CoopPlayer coopPlayer = alivePlayers[0];
+					freeCamScript.SetCurrentPlayer(coopPlayer);
+					FikaPlugin.Instance.FikaLogger.LogDebug("FreecamController: Spectating new player: " + coopPlayer.Profile.Info.MainProfileNickname);
+
+					player.PointOfView = EPointOfView.ThirdPerson;
+					if (player.PlayerBody != null)
+					{
+						player.PlayerBody.PointOfView.Value = EPointOfView.FreeCamera;
+						player.GetComponent<PlayerCameraController>().UpdatePointOfView();
+					}
+					gamePlayerOwner.enabled = false;
+					freeCamScript.SetActive(true);
+
+					freeCamScript.Attach3rdPerson();
+					return;
 				}
 			}
 		}

--- a/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
+++ b/Fika.Core/Coop/FreeCamera/FreeCameraController.cs
@@ -33,6 +33,7 @@ namespace Fika.Core.Coop.FreeCamera
 
 		private GamePlayerOwner gamePlayerOwner;
 		private CoopPlayer player => (CoopPlayer)Singleton<GameWorld>.Instance.MainPlayer;
+		private Vector3 LastKnownPosition;
 		private CoopHandler coopHandler;
 
 		public GameObject CameraParent;
@@ -132,6 +133,10 @@ namespace Fika.Core.Coop.FreeCamera
 			}
 
 			CoopHandler.EQuitState quitState = coopHandler.GetQuitState();
+			if (quitState != CoopHandler.EQuitState.YouHaveExtracted)
+			{
+				LastKnownPosition = player.PlayerBones.Neck.position;
+			}
 
 			if (extracted && !freeCamScript.IsActive)
 			{
@@ -163,6 +168,7 @@ namespace Fika.Core.Coop.FreeCamera
 
 			if (quitState == CoopHandler.EQuitState.YouHaveExtracted && !extracted)
 			{
+				FikaPlugin.Instance.FikaLogger.LogDebug($"Freecam: player has extracted");
 				CoopGame coopGame = coopHandler.LocalGameInstance;
 				if (coopGame.ExtractedPlayers.Contains(player.NetId))
 				{
@@ -357,7 +363,8 @@ namespace Fika.Core.Coop.FreeCamera
 					List<CoopPlayer> alivePlayers = [.. coopHandler.HumanPlayers.Where(x => !x.IsYourPlayer && x.HealthController.IsAlive)];
 					if (alivePlayers.Count <= 0)
 					{
-						// No alive players to attach to at this time, so let's fallback to freecam
+						// No alive players to attach to at this time, so let's fallback to freecam on last known position
+						freeCamScript.transform.position = LastKnownPosition;
 						ToggleCamera();
 						return;
 					}

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -189,18 +189,18 @@ namespace Fika.Core
 		public static ConfigEntry<bool> DisableBotMetabolism { get; set; }
 		#endregion
 
-        #region client config
-        public bool UseBTR;
-        public bool FriendlyFire;
-        public bool DynamicVExfils;
-        public bool AllowFreeCam;
-        public bool AllowSpectateFreeCam;
-        public bool AllowItemSending;
-        public string[] BlacklistedItems;
-        public bool ForceSaveOnDeath;
-        public bool UseInertia;
-        public bool SharedQuestProgression;
-        #endregion
+		#region client config
+		public bool UseBTR;
+		public bool FriendlyFire;
+		public bool DynamicVExfils;
+		public bool AllowFreeCam;
+		public bool AllowSpectateFreeCam;
+		public bool AllowItemSending;
+		public string[] BlacklistedItems;
+		public bool ForceSaveOnDeath;
+		public bool UseInertia;
+		public bool SharedQuestProgression;
+		#endregion
 
 		#region natpunch config
 		public bool NatPunchServerEnable;
@@ -284,16 +284,16 @@ namespace Fika.Core
 		{
 			ClientConfigModel clientConfig = FikaRequestHandler.GetClientConfig();
 
-            UseBTR = clientConfig.UseBTR;
-            FriendlyFire = clientConfig.FriendlyFire;
-            DynamicVExfils = clientConfig.DynamicVExfils;
-            AllowFreeCam = clientConfig.AllowFreeCam;
-            AllowSpectateFreeCam = clientConfig.AllowSpectateFreeCam;
-            AllowItemSending = clientConfig.AllowItemSending;
-            BlacklistedItems = clientConfig.BlacklistedItems;
-            ForceSaveOnDeath = clientConfig.ForceSaveOnDeath;
-            UseInertia = clientConfig.UseInertia;
-            SharedQuestProgression = clientConfig.SharedQuestProgression;
+			UseBTR = clientConfig.UseBTR;
+			FriendlyFire = clientConfig.FriendlyFire;
+			DynamicVExfils = clientConfig.DynamicVExfils;
+			AllowFreeCam = clientConfig.AllowFreeCam;
+			AllowSpectateFreeCam = clientConfig.AllowSpectateFreeCam;
+			AllowItemSending = clientConfig.AllowItemSending;
+			BlacklistedItems = clientConfig.BlacklistedItems;
+			ForceSaveOnDeath = clientConfig.ForceSaveOnDeath;
+			UseInertia = clientConfig.UseInertia;
+			SharedQuestProgression = clientConfig.SharedQuestProgression;
 
 			clientConfig.LogValues();
 		}

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -189,17 +189,18 @@ namespace Fika.Core
 		public static ConfigEntry<bool> DisableBotMetabolism { get; set; }
 		#endregion
 
-		#region client config
-		public bool UseBTR;
-		public bool FriendlyFire;
-		public bool DynamicVExfils;
-		public bool AllowFreeCam;
-		public bool AllowItemSending;
-		public string[] BlacklistedItems;
-		public bool ForceSaveOnDeath;
-		public bool UseInertia;
-		public bool SharedQuestProgression;
-		#endregion
+        #region client config
+        public bool UseBTR;
+        public bool FriendlyFire;
+        public bool DynamicVExfils;
+        public bool AllowFreeCam;
+        public bool AllowSpectateFreeCam;
+        public bool AllowItemSending;
+        public string[] BlacklistedItems;
+        public bool ForceSaveOnDeath;
+        public bool UseInertia;
+        public bool SharedQuestProgression;
+        #endregion
 
 		#region natpunch config
 		public bool NatPunchServerEnable;
@@ -283,15 +284,16 @@ namespace Fika.Core
 		{
 			ClientConfigModel clientConfig = FikaRequestHandler.GetClientConfig();
 
-			UseBTR = clientConfig.UseBTR;
-			FriendlyFire = clientConfig.FriendlyFire;
-			DynamicVExfils = clientConfig.DynamicVExfils;
-			AllowFreeCam = clientConfig.AllowFreeCam;
-			AllowItemSending = clientConfig.AllowItemSending;
-			BlacklistedItems = clientConfig.BlacklistedItems;
-			ForceSaveOnDeath = clientConfig.ForceSaveOnDeath;
-			UseInertia = clientConfig.UseInertia;
-			SharedQuestProgression = clientConfig.SharedQuestProgression;
+            UseBTR = clientConfig.UseBTR;
+            FriendlyFire = clientConfig.FriendlyFire;
+            DynamicVExfils = clientConfig.DynamicVExfils;
+            AllowFreeCam = clientConfig.AllowFreeCam;
+            AllowSpectateFreeCam = clientConfig.AllowSpectateFreeCam;
+            AllowItemSending = clientConfig.AllowItemSending;
+            BlacklistedItems = clientConfig.BlacklistedItems;
+            ForceSaveOnDeath = clientConfig.ForceSaveOnDeath;
+            UseInertia = clientConfig.UseInertia;
+            SharedQuestProgression = clientConfig.SharedQuestProgression;
 
 			clientConfig.LogValues();
 		}

--- a/Fika.Core/Models/ClientConfigModel.cs
+++ b/Fika.Core/Models/ClientConfigModel.cs
@@ -19,8 +19,11 @@ namespace Fika.Core.UI.Models
 		[DataMember(Name = "allowFreeCam")]
 		public bool AllowFreeCam;
 
-		[DataMember(Name = "allowItemSending")]
-		public bool AllowItemSending;
+        [DataMember(Name = "AllowSpectateFreeCam")]
+        public bool AllowSpectateFreeCam;
+
+        [DataMember(Name = "allowItemSending")]
+        public bool AllowItemSending;
 
 		[DataMember(Name = "blacklistedItems")]
 		public string[] BlacklistedItems;
@@ -34,19 +37,20 @@ namespace Fika.Core.UI.Models
 		[DataMember(Name = "sharedQuestProgression")]
 		public bool SharedQuestProgression;
 
-		public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowItemSending, string[] blacklistedItems, bool forceSaveOnDeath, bool useInertia,
-			bool sharedQuestProgression)
-		{
-			UseBTR = useBTR;
-			FriendlyFire = friendlyFire;
-			DynamicVExfils = dynamicVExfils;
-			AllowFreeCam = allowFreeCam;
-			AllowItemSending = allowItemSending;
-			BlacklistedItems = blacklistedItems;
-			ForceSaveOnDeath = forceSaveOnDeath;
-			UseInertia = useInertia;
-			SharedQuestProgression = sharedQuestProgression;
-		}
+        public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowDeathFreeCam, bool allowItemSending, string[] blacklistedItems, bool forceSaveOnDeath, bool useInertia,
+            bool sharedQuestProgression)
+        {
+            UseBTR = useBTR;
+            FriendlyFire = friendlyFire;
+            DynamicVExfils = dynamicVExfils;
+            AllowFreeCam = allowFreeCam;
+            AllowSpectateFreeCam = allowDeathFreeCam;
+            AllowItemSending = allowItemSending;
+            BlacklistedItems = blacklistedItems;
+            ForceSaveOnDeath = forceSaveOnDeath;
+            UseInertia = useInertia;
+            SharedQuestProgression = sharedQuestProgression;
+        }
 
 		public void LogValues()
 		{

--- a/Fika.Core/Models/ClientConfigModel.cs
+++ b/Fika.Core/Models/ClientConfigModel.cs
@@ -19,11 +19,11 @@ namespace Fika.Core.UI.Models
 		[DataMember(Name = "allowFreeCam")]
 		public bool AllowFreeCam;
 
-        [DataMember(Name = "AllowSpectateFreeCam")]
-        public bool AllowSpectateFreeCam;
+		[DataMember(Name = "AllowSpectateFreeCam")]
+		public bool AllowSpectateFreeCam;
 
-        [DataMember(Name = "allowItemSending")]
-        public bool AllowItemSending;
+		[DataMember(Name = "allowItemSending")]
+		public bool AllowItemSending;
 
 		[DataMember(Name = "blacklistedItems")]
 		public string[] BlacklistedItems;
@@ -37,20 +37,20 @@ namespace Fika.Core.UI.Models
 		[DataMember(Name = "sharedQuestProgression")]
 		public bool SharedQuestProgression;
 
-        public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowDeathFreeCam, bool allowItemSending, string[] blacklistedItems, bool forceSaveOnDeath, bool useInertia,
-            bool sharedQuestProgression)
-        {
-            UseBTR = useBTR;
-            FriendlyFire = friendlyFire;
-            DynamicVExfils = dynamicVExfils;
-            AllowFreeCam = allowFreeCam;
-            AllowSpectateFreeCam = allowDeathFreeCam;
-            AllowItemSending = allowItemSending;
-            BlacklistedItems = blacklistedItems;
-            ForceSaveOnDeath = forceSaveOnDeath;
-            UseInertia = useInertia;
-            SharedQuestProgression = sharedQuestProgression;
-        }
+		public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowDeathFreeCam, bool allowItemSending, string[] blacklistedItems, bool forceSaveOnDeath, bool useInertia,
+			bool sharedQuestProgression)
+		{
+			UseBTR = useBTR;
+			FriendlyFire = friendlyFire;
+			DynamicVExfils = dynamicVExfils;
+			AllowFreeCam = allowFreeCam;
+			AllowSpectateFreeCam = allowDeathFreeCam;
+			AllowItemSending = allowItemSending;
+			BlacklistedItems = blacklistedItems;
+			ForceSaveOnDeath = forceSaveOnDeath;
+			UseInertia = useInertia;
+			SharedQuestProgression = sharedQuestProgression;
+		}
 
 		public void LogValues()
 		{

--- a/Fika.Core/Models/ClientConfigModel.cs
+++ b/Fika.Core/Models/ClientConfigModel.cs
@@ -37,14 +37,14 @@ namespace Fika.Core.UI.Models
 		[DataMember(Name = "sharedQuestProgression")]
 		public bool SharedQuestProgression;
 
-		public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowDeathFreeCam, bool allowItemSending, string[] blacklistedItems, bool forceSaveOnDeath, bool useInertia,
+		public ClientConfigModel(bool useBTR, bool friendlyFire, bool dynamicVExfils, bool allowFreeCam, bool allowSpectateFreeCam, bool allowItemSending, string[] blacklistedItems, bool forceSaveOnDeath, bool useInertia,
 			bool sharedQuestProgression)
 		{
 			UseBTR = useBTR;
 			FriendlyFire = friendlyFire;
 			DynamicVExfils = dynamicVExfils;
 			AllowFreeCam = allowFreeCam;
-			AllowSpectateFreeCam = allowDeathFreeCam;
+			AllowSpectateFreeCam = allowSpectateFreeCam;
 			AllowItemSending = allowItemSending;
 			BlacklistedItems = blacklistedItems;
 			ForceSaveOnDeath = forceSaveOnDeath;


### PR DESCRIPTION
Server PR to add config option: https://github.com/project-fika/Fika-Server/pull/74

Adds a new server-side option `allowSpectateFreeCam` that allows controlling the ability to freecam on death/extract.

If the option is set to `false`, on death/extract the current player is swapped to third person cam of the next available alive player. LMB/RMB swaps between players in third person view, instead of jumping to player positions in freecam. The usual keybinds work (Space + L/R to headcam, etc). If there are no alive players remaining, the camera switches to freecam mode.

### Test scenarios
- [x] Still allows Freecam if `allowFreeCam` is enabled
- [x] Freecam functionality retained when main player dies while in freecam
- [x] When spectated player dies, swap to freecam if no other alive players
- [x] When all players are dead/extracted, swap to freecam
- [x] When self has extracted, snap to last known position before extract
- [x] When observing a player that then extracts, snap to last known position of that player from before they extracted 
- [x] `allowSpectateFreeCam` set to true still works as expected (on player death switch to next alive player in freecam mode, on player extract and no alive players swap to freecam on last known position) 

### TODO
- [x] Do not follow extracted player model up into the sky (attach to exfil point when spectated player is destroyed)
- [x] Do the above for self too