### PR TITLE
Extend DestroyNetworkedComponents from 2 seconds to 10 seconds

### DIFF
--- a/Fika.Core/Coop/Players/ObservedCoopPlayer.cs
+++ b/Fika.Core/Coop/Players/ObservedCoopPlayer.cs
@@ -1021,7 +1021,7 @@ namespace Fika.Core.Coop.Players
 
 		private IEnumerator DestroyNetworkedComponents()
 		{
-			yield return new WaitForSeconds(2);
+			yield return new WaitForSeconds(10);
 
 			if (Speaker != null)
 			{


### PR DESCRIPTION
Otherwise the speaker gets disposed of too early

**UNTESTED**