### PR TITLE
Fika Core changes for automatic headless restart

### DIFF
--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -399,7 +399,7 @@ namespace Fika.Core
             {
                 yield return null;
             }
-            WanIP = addressTask.Result;
+                WanIP = addressTask.Result;
 
             yield return new WaitForSeconds(5);
             VerifyServerVersion();

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -399,7 +399,8 @@ namespace Fika.Core
             {
                 yield return null;
             }
-                WanIP = addressTask.Result;
+            
+            WanIP = addressTask.Result;
 
             yield return new WaitForSeconds(5);
             VerifyServerVersion();

--- a/Fika.Core/Models/HeadlessConfigModel.cs
+++ b/Fika.Core/Models/HeadlessConfigModel.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Fika.Core.UI.Models
+{
+    [DataContract]
+    public struct HeadlessProfiles
+    {
+        [DataMember(Name = "amount")]
+        public int Amount { get; set; }
+
+        [DataMember(Name = "aliases")]
+        public Dictionary<string, string> Aliases { get; set; }
+    }
+
+    [DataContract]
+    public struct HeadlessScripts
+    {
+        [DataMember(Name = "generate")]
+        public bool Generate { get; set; }
+
+        [DataMember(Name = "forceIp")]
+        public string ForceIp { get; set; }
+    }
+    
+    [DataContract]
+    public struct HeadlessConfigModel
+    {
+        [DataMember(Name = "profiles")]
+        public HeadlessProfiles Profiles { get; set; }
+
+        [DataMember(Name = "scripts")]
+        public HeadlessScripts Scripts { get; set; }
+
+        [DataMember(Name = "setLevelToAverageOfLobby")]
+        public bool SetLevelToAverageOfLobby { get; set; }
+
+        [DataMember(Name = "restartAfterAmountOfRaids")]
+        public int RestartAfterAmountOfRaids { get; set; }
+
+        public void LogValues()
+        {
+            FikaPlugin.Instance.FikaLogger.LogInfo("Received Headless config from server:");
+            FieldInfo[] fields = typeof(HeadlessConfigModel).GetFields();
+            foreach (FieldInfo field in fields)
+            {
+                object value = field.GetValue(this);
+                if (value is Array valueArray)
+                {
+                    string values = "";
+                    for (int i = 0; i < valueArray.Length; i++)
+                    {
+                        if (i == 0)
+                        {
+                            values = valueArray.GetValue(i).ToString();
+                            continue;
+                        }
+                        values = values + ", " + valueArray.GetValue(i).ToString();
+                    }
+                    FikaPlugin.Instance.FikaLogger.LogInfo(field.Name + ": " + values);
+                    continue;
+                }
+                FikaPlugin.Instance.FikaLogger.LogInfo(field.Name + ": " + value);
+            }
+        }
+    }
+}

--- a/Fika.Core/Networking/FikaServer.cs
+++ b/Fika.Core/Networking/FikaServer.cs
@@ -212,7 +212,6 @@ namespace Fika.Core.Networking
 #if DEBUG
             AddDebugPackets();
 #endif            
-
             if (FikaPlugin.UseUPnP.Value && !FikaPlugin.UseNatPunching.Value)
             {
                 bool upnpFailed = false;
@@ -245,9 +244,8 @@ namespace Fika.Core.Networking
             }
             else
             {
-                externalIp = FikaPlugin.Instance.WanIP.ToString();
+                externalIp = FikaPlugin.Instance.WanIP?.ToString();
             }
-
             if (FikaPlugin.UseNatPunching.Value)
             {
                 netServer.NatPunchModule.UnsyncedEvents = true;

--- a/Fika.Core/Networking/FikaServer.cs
+++ b/Fika.Core/Networking/FikaServer.cs
@@ -246,6 +246,7 @@ namespace Fika.Core.Networking
             {
                 externalIp = FikaPlugin.Instance.WanIP?.ToString();
             }
+
             if (FikaPlugin.UseNatPunching.Value)
             {
                 netServer.NatPunchModule.UnsyncedEvents = true;

--- a/Fika.Core/Networking/FikaServer.cs
+++ b/Fika.Core/Networking/FikaServer.cs
@@ -244,7 +244,12 @@ namespace Fika.Core.Networking
             }
             else
             {
-                externalIp = FikaPlugin.Instance.WanIP?.ToString();
+                if (FikaPlugin.Instance.WanIP == null)
+                {
+                    throw new NullReferenceException("Failed to start Fika Server because WAN IP was null!");
+                }
+
+                externalIp = FikaPlugin.Instance.WanIP.ToString();
             }
 
             if (FikaPlugin.UseNatPunching.Value)

--- a/Fika.Core/Networking/Http/FikaRequestHandler.cs
+++ b/Fika.Core/Networking/Http/FikaRequestHandler.cs
@@ -121,6 +121,11 @@ namespace Fika.Core.Networking.Http
             return GetJson<NatPunchServerConfigModel>("/fika/natpunchserver/config");
         }
 
+        public static HeadlessConfigModel GetHeadlessConfig()
+        {
+            return GetJson<HeadlessConfigModel>("/fika/headless/config");
+        }
+
         public static async Task UpdatePing(PingRequest data)
         {
             await PutJsonAsync("/fika/update/ping", data);


### PR DESCRIPTION
## Describe your changes
Fika Core changes for automatic headless restart. Added model and request handler to retrieve headless config from fika.jsonc.
Also fixed a null reference on WanIP when no public IP are provided (probably due to requesting the public IP too many times).
## Related issue

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have thoroughly tested the code changes
- [x] I have thoroughly tested the code changes on a dedicated session