### PR TITLE
Add missing parameters to fix wrong spawn point when using transit to travel between maps on headless client.

### DIFF
--- a/Fika.Core/Coop/GameMode/CoopGame.cs
+++ b/Fika.Core/Coop/GameMode/CoopGame.cs
@@ -1550,7 +1550,7 @@ namespace Fika.Core.Coop.GameMode
             int spawnSafeDistance = (Location_0.SpawnSafeDistanceMeters > 0) ? Location_0.SpawnSafeDistanceMeters : 100;
             SpawnSettingsStruct settings = new(Location_0.MinDistToFreePoint, Location_0.MaxDistToFreePoint, Location_0.MaxBotPerZone, spawnSafeDistance);
             SpawnSystem = SpawnSystemCreatorClass.CreateSpawnSystem(settings, FikaGlobals.GetApplicationTime, Singleton<GameWorld>.Instance, botsController_0, spawnPoints);
-            spawnPoint = SpawnSystem.SelectSpawnPoint(ESpawnCategory.Player, Profile_0.Info.Side);
+            spawnPoint = SpawnSystem.SelectSpawnPoint(ESpawnCategory.Player, Profile_0.Info.Side, null, null, null, null, Profile_0.Id);
             InfiltrationPoint = spawnPoint.Infiltration;
             if (!isServer)
             {


### PR DESCRIPTION
## Describe your changes
Add missing parameters to fix wrong spawn point when using transit to travel between maps on headless client.

## Related issue

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have thoroughly tested the code changes
- [X] I have thoroughly tested the code changes on a dedicated session