### PR TITLE
Fix the GetPublicIP method can't catch error and stuck on this logic.

### DIFF
--- a/Fika.Core/Networking/Http/FikaRequestHandler.cs
+++ b/Fika.Core/Networking/Http/FikaRequestHandler.cs
@@ -30,12 +30,11 @@ namespace Fika.Core.Networking.Http
         public static async Task<IPAddress> GetPublicIP()
         {
             HttpClient client = Traverse.Create(_httpClient).Field<HttpClient>("_httpv").Value;
-            string[] urls = new[]
-            {
-                "https://api.ipify.org/",
+            string[] urls = [
+                "https://api.ip.sb/ip",
                 "https://checkip.amazonaws.com/",
                 "https://ipv4.icanhazip.com/"
-            };
+            ];
 
             foreach (string url in urls)
             {

--- a/Fika.Core/Networking/Http/FikaRequestHandler.cs
+++ b/Fika.Core/Networking/Http/FikaRequestHandler.cs
@@ -30,35 +30,38 @@ namespace Fika.Core.Networking.Http
         public static async Task<IPAddress> GetPublicIP()
         {
             HttpClient client = Traverse.Create(_httpClient).Field<HttpClient>("_httpv").Value;
-            string ipString = await client.GetStringAsync("https://api.ipify.org/");
-            ipString = ipString.Replace("\n", "");
-            if (IPAddress.TryParse(ipString, out IPAddress ipAddress))
+            string[] urls = new[]
             {
-                if (ipAddress.AddressFamily is AddressFamily.InterNetwork)
-                {
-                    return ipAddress;
-                }
-                throw new ArgumentException($"IP address was not an IPv4 address, was: {ipAddress.AddressFamily}, address: {ipAddress}!");
-            }
-            ipString = await client.GetStringAsync("https://checkip.amazonaws.com/");
-            if (IPAddress.TryParse(ipString, out ipAddress))
+                "https://api.ipify.org/",
+                "https://checkip.amazonaws.com/",
+                "https://ipv4.icanhazip.com/"
+            };
+
+            foreach (string url in urls)
             {
-                if (ipAddress.AddressFamily is AddressFamily.InterNetwork)
+                try
                 {
-                    return ipAddress;
+                    string ipString = await client.GetStringAsync(url);
+                    ipString = ipString.Trim();
+                    if (IPAddress.TryParse(ipString, out IPAddress ipAddress))
+                    {
+                        if (ipAddress.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            return ipAddress;
+                        }
+                        throw new ArgumentException($"IP address was not an IPv4 address, was: {ipAddress.AddressFamily}, address: {ipAddress}!");
+                    }
                 }
-                throw new ArgumentException($"IP address was not an IPv4 address, was: {ipAddress.AddressFamily}, address: {ipAddress}!");
-            }
-            ipString = await client.GetStringAsync("https://ipv4.icanhazip.com/");
-            if (IPAddress.TryParse(ipString, out ipAddress))
-            {
-                if (ipAddress.AddressFamily is AddressFamily.InterNetwork)
+                catch (Exception ex)
                 {
-                    return ipAddress;
+#if DEBUG
+                    FikaPlugin.Instance.FikaLogger.LogWarning($"Could not get public IP address by [{url}], Error message: {ex.Message}");
+#endif
+                    continue;
                 }
-                throw new ArgumentException($"IP address was not an IPv4 address, was: {ipAddress.AddressFamily}, address: {ipAddress}!");
             }
-            throw new Exception("Could not retrieve or parse the external address!");
+
+            throw new Exception("Could not retrieve or parse the external IP address!");
         }
 
         private static byte[] EncodeBody<T>(T o)


### PR DESCRIPTION
## Describe your changes
Fix the GetPublicIP method can't catch error and stuck on this logic.
For example, a connection error occurs when making the first API request, the error will appear in the console and subsequent logic will not continue to execute.This will cause can't check mod and let Fika plugin crc32 keep 0.

## Related issue
None

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have thoroughly tested the code changes
- [X] I have thoroughly tested the code changes on a dedicated session