### PR TITLE
added advanced option to Despawn Only Scavs when Enforced Spawn Limits and Despawn Furthest are enabled

### DIFF
--- a/Fika.Core/Coop/GameMode/HostGameController.cs
+++ b/Fika.Core/Coop/GameMode/HostGameController.cs
@@ -336,7 +336,9 @@ namespace Fika.Core.Coop.GameMode
         {
             List<CoopPlayer> humanPlayers = BotExtensions.GetPlayers(coopHandler);
 
-            string botKey = BotExtensions.GetFurthestBot(humanPlayers, Bots, out float furthestDistance);
+            bool onlyScavs = FikaPlugin.DespawnOnlyScavs.Value;
+
+            string botKey = BotExtensions.GetFurthestBot(humanPlayers, Bots, out float furthestDistance, onlyScavs);
 
             if (botKey == string.Empty)
             {

--- a/Fika.Core/Coop/Utils/BotExtensions.cs
+++ b/Fika.Core/Coop/Utils/BotExtensions.cs
@@ -59,7 +59,7 @@ namespace Fika.Core.Coop.Utils
         /// <param name="humanPlayers">List of all human <see cref="CoopPlayer"/>s</param>
         /// <param name="furthestDistance">The furthest <see cref="float"/> distance</param>
         /// <returns></returns>
-        public static string GetFurthestBot(List<CoopPlayer> humanPlayers, Dictionary<string, Player> bots, out float furthestDistance)
+        public static string GetFurthestBot(List<CoopPlayer> humanPlayers, Dictionary<string, Player> bots, out float furthestDistance, bool onlyScavs = false)
         {
             string furthestBot = string.Empty;
             furthestDistance = 0f;
@@ -67,6 +67,12 @@ namespace Fika.Core.Coop.Utils
             foreach (KeyValuePair<string, Player> botKeyValuePair in bots)
             {
                 if (IsInvalidBotForDespawning(botKeyValuePair))
+                {
+                    continue;
+                }
+
+                //if set to only despawn scavs, skip anything that is not WildSpawnType.assault
+                if (onlyScavs && botKeyValuePair.Value.Profile.Info.Settings.Role != WildSpawnType.assault)
                 {
                     continue;
                 }

--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -183,6 +183,7 @@ namespace Fika.Core
         // Performance | Bot Limits            
         public static ConfigEntry<bool> EnforcedSpawnLimits { get; set; }
         public static ConfigEntry<bool> DespawnFurthest { get; set; }
+        public static ConfigEntry<bool> DespawnOnlyScavs { get; set; }
         public static ConfigEntry<float> DespawnMinimumDistance { get; set; }
         public static ConfigEntry<int> MaxBotsFactory { get; set; }
         public static ConfigEntry<int> MaxBotsCustoms { get; set; }
@@ -1022,7 +1023,7 @@ namespace Fika.Core
                 {
                     Category = performanceBotsHeader,
                     DispName = LocaleUtils.BEPINEX_ENFORCED_SPAWN_LIMITS_T.Localized(),
-                    Order = 14
+                    Order = 15
                 }),
                 "Enforced Spawn Limits", ref failed, headers);
 
@@ -1031,9 +1032,19 @@ namespace Fika.Core
                 {
                     Category = performanceBotsHeader,
                     DispName = LocaleUtils.BEPINEX_DESPAWN_FURTHEST_T.Localized(),
-                    Order = 13
+                    Order = 14
                 }),
                 "Despawn Furthest", ref failed, headers);
+
+            DespawnOnlyScavs = SetupSetting(performanceDefaultBotsHeader, "Despawn Only Scavs", false,
+                new ConfigDescription(LocaleUtils.BEPINEX_DESPAWN_ONLY_SCAVS_D.Localized(), tags: new ConfigurationManagerAttributes()
+                {
+                    Category = performanceBotsHeader,
+                    DispName = LocaleUtils.BEPINEX_DESPAWN_ONLY_SCAVS_T.Localized(),
+                    Order = 13,
+                    IsAdvanced = true
+                }),
+                "Despawn Only Scavs", ref failed, headers);
 
             DespawnMinimumDistance = SetupSetting(performanceDefaultBotsHeader, "Despawn Minimum Distance", 200.0f,
                 new ConfigDescription(LocaleUtils.BEPINEX_DESPAWN_MIN_DISTANCE_D.Localized(),

--- a/Fika.Core/Utils/LocaleUtils.cs
+++ b/Fika.Core/Utils/LocaleUtils.cs
@@ -343,6 +343,8 @@ namespace Fika.Core.Utils
         public const string BEPINEX_ENFORCED_SPAWN_LIMITS_D = "F_BepInEx_EnforcedSpawnLimits_D";
         public const string BEPINEX_DESPAWN_FURTHEST_T = "F_BepInEx_DespawnFurthest_T";
         public const string BEPINEX_DESPAWN_FURTHEST_D = "F_BepInEx_DespawnFurthest_D";
+        public const string BEPINEX_DESPAWN_ONLY_SCAVS_T = "F_BepInEx_DespawnOnlyScavs_T";
+        public const string BEPINEX_DESPAWN_ONLY_SCAVS_D = "F_BepInEx_DespawnOnlyScavs_D";
         public const string BEPINEX_DESPAWN_MIN_DISTANCE_T = "F_BepInEx_DespawnMinDistance_T";
         public const string BEPINEX_DESPAWN_MIN_DISTANCE_D = "F_BepInEx_DespawnMinDistance_D";
         public const string BEPINEX_MAX_BOTS_T = "F_BepInEx_MaxBots_T";


### PR DESCRIPTION
## Describe your changes
- Added a boolean to BotExtensions.GetFurthestBot to implement a simple Info.Settings.Role check for returning only a Scav.
- Added an advanced setting under Despawn Furthest called Despawn Only Scavs.

This is intended to be to help users who prefer to use starting-pmcs from MOAR or Questing Bots.

In testing across a dozen or so raids (Streets, Woods, Customs) I never once saw anything despawned successfully, even with my changes reverted. I don't know if this has something to do with new bot spawn waves or what, and obviously I did not test this with any bot spawn mod.

I cannot imagine it causing any problems, but I'm also only making this PR because I already went to the effort and I'd hate to waste it.

There's a sister PR on the server mod for localization.

## Related issue
None

## Checklist before requesting a review
- [ yes ] I have performed a self-review of my code
- [ yes ] I have thoroughly tested the code changes
- [ no ] I have thoroughly tested the code changes on a dedicated session