### PR TITLE
Freecam player list and logic changes

### DIFF
--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -119,6 +119,7 @@ public class FikaPlugin : BaseUnityPlugin
     public static ConfigEntry<bool> AutoExtract { get; set; }
     public static ConfigEntry<bool> ShowExtractMessage { get; set; }
     public static ConfigEntry<KeyboardShortcut> ExtractKey { get; set; }
+    public static ConfigEntry<bool> ShowPlayerList { get; set; }
     public static ConfigEntry<bool> EnableChat { get; set; }
     public static ConfigEntry<KeyboardShortcut> ChatKey { get; set; }
     public static ConfigEntry<bool> EnableOnlinePlayers { get; set; }
@@ -506,7 +507,7 @@ public class FikaPlugin : BaseUnityPlugin
             {
                 Category = coopHeader,
                 DispName = LocaleUtils.BEPINEX_USE_HEADLESS_T.Localized(),
-                Order = 8
+                Order = 9
             }), "Auto Use Headless", ref failed, headers);
 
         ShowNotifications = SetupSetting(coopDefaultHeader, "Show Feed", true,
@@ -514,7 +515,7 @@ public class FikaPlugin : BaseUnityPlugin
             {
                 Category = coopHeader,
                 DispName = LocaleUtils.BEPINEX_SHOW_FEED_T.Localized(),
-                Order = 7
+                Order = 8
             }),
             "Show Feed", ref failed, headers);
 
@@ -523,7 +524,7 @@ public class FikaPlugin : BaseUnityPlugin
             {
                 Category = coopHeader,
                 DispName = LocaleUtils.BEPINEX_AUTO_EXTRACT_T.Localized(),
-                Order = 6
+                Order = 7
             }),
             "Auto Extract", ref failed, headers);
 
@@ -532,7 +533,7 @@ public class FikaPlugin : BaseUnityPlugin
             {
                 Category = coopHeader,
                 DispName = LocaleUtils.BEPINEX_SHOW_EXTRACT_MESSAGE_T.Localized(),
-                Order = 5
+                Order = 6
             }),
             "Show Extract Message", ref failed, headers);
 
@@ -541,9 +542,19 @@ public class FikaPlugin : BaseUnityPlugin
             {
                 Category = coopHeader,
                 DispName = LocaleUtils.BEPINEX_EXTRACT_KEY_T.Localized(),
-                Order = 4
+                Order = 5
             }),
             "Extract Key", ref failed, headers);
+
+        ShowPlayerList = SetupSetting(coopDefaultHeader, "Show In-Game Player List", true,
+            new ConfigDescription(LocaleUtils.BEPINEX_SHOW_EXTRACT_MESSAGE_D.Localized(), tags: new ConfigurationManagerAttributes() // TODO
+            {
+                Category = coopHeader,
+                /* DispName = LocaleUtils.BEPINEX_SHOW_EXTRACT_MESSAGE_T.Localized(), */ // TODO
+                DispName = "Show Player List",
+                Order = 4
+            }),
+            "Show In-Game Player List", ref failed, headers);
 
         EnableChat = SetupSetting(coopDefaultHeader, "Enable Chat", false,
             new ConfigDescription(LocaleUtils.BEPINEX_ENABLE_CHAT_D.Localized(), tags: new ConfigurationManagerAttributes()

--- a/Fika.Core/Main/FreeCamera/FreeCamera.cs
+++ b/Fika.Core/Main/FreeCamera/FreeCamera.cs
@@ -406,7 +406,7 @@ public class FreeCamera : MonoBehaviour
 
     protected void OnGUI()
     {
-        if (!IsActive || !_showOverlay || _hidePlayerList)
+        if (!IsActive || !_showOverlay || _hidePlayerList || !FikaPlugin.ShowPlayerList.Value)
         {
             return;
         }

--- a/Fika.Core/UI/Custom/FikaSettingsScreen/FikaSettings.cs
+++ b/Fika.Core/UI/Custom/FikaSettingsScreen/FikaSettings.cs
@@ -54,6 +54,7 @@ public class FikaSettings : SettingsTab
     private SettingToggle _autoExtract;
     private SettingToggle _showExtractMessage;
     private GameObject _extractKey;
+    private SettingToggle _showPlayerList;
     private KeybindHandler _extractKeyHandler;
     private SettingToggle _enableChat;
     private GameObject _chatKey;
@@ -152,6 +153,7 @@ public class FikaSettings : SettingsTab
         _autoExtract = CreateToggle(section2);
         _showExtractMessage = CreateToggle(section2);
         _extractKey = CreateKeybind(content);
+        _showPlayerList = CreateToggle(section2);
         RectTransform section3 = CreateSubSection(content);
         _enableChat = CreateToggle(section3);
         _chatKey = CreateKeybind(content);
@@ -281,6 +283,7 @@ public class FikaSettings : SettingsTab
         SetupToggle(_autoExtract, FikaPlugin.AutoExtract);
         SetupToggle(_showExtractMessage, FikaPlugin.ShowExtractMessage);
         _extractKeyHandler = SetupKeybind(_extractKey, FikaPlugin.ExtractKey);
+        SetupToggle(_showPlayerList, FikaPlugin.ShowPlayerList);
         SetupToggle(_enableChat, FikaPlugin.EnableChat);
         _chatKeyHandler = SetupKeybind(_chatKey, FikaPlugin.ChatKey);
         SetupToggle(_onlinePlayers, FikaPlugin.EnableOnlinePlayers);


### PR DESCRIPTION
This adds an imgui player list in the freecam and makes some logic changes to the freecam.

- Detaching and reattaching remembers the last player
- Pressing G while detached reattaches to the last player, as does left or right click
- Pressing space immediately switches between first person headcam and third person when not detached, rather than holding space while cycling players
- Pressing Ctrl toggles superFastMode rather than holding it down
- Camera moved away from and adjusted to point towards player in third person camera mode
- Pressing L toggles showing player list

## Third person:
![Screenshot_628](https://github.com/user-attachments/assets/dadb27d0-8c7e-418e-a3e4-dd786185b335)
![Screenshot_626](https://github.com/user-attachments/assets/fe03f13d-2a33-4294-b985-14b12ccc1eed)

## Detached: 
![Screenshot_629](https://github.com/user-attachments/assets/0f5cf46b-1178-4a16-b356-fad183bfa249)

## Health bar color goes from green to orange to red:
![Screenshot_630](https://github.com/user-attachments/assets/9096536c-ee63-49da-a1e7-494b09a95a7a)


I have not tested with other human players in the lobby, but I copied getting the player list from CycleSpectatePlayers, so in theory it should just show other human players for whom spectating is allowed until there are no human players left in raid.