### PR TITLE
Fix ProjectToCanvas for optic scopes

### DIFF
--- a/Fika.Core/Main/Utils/WorldToScreen.cs
+++ b/Fika.Core/Main/Utils/WorldToScreen.cs
@@ -24,6 +24,9 @@ public static class WorldToScreen
 
         var projCam = camClass.Camera;
 
+        Vector2 canvasSize = canvasRect.sizeDelta;
+        float scaleFactor = 1f;
+
         // Use optic camera if zoomed
         if (useOpticCamera && IsZoomedOpticAiming(mainPlayer.ProceduralWeaponAnimation))
         {
@@ -31,6 +34,8 @@ public static class WorldToScreen
             if (opticCam != null)
             {
                 projCam = opticCam;
+                canvasSize = opticCam.pixelRect.max;
+                scaleFactor = canvasRect.sizeDelta.x / Screen.width;
             }
         }
 
@@ -43,8 +48,8 @@ public static class WorldToScreen
         }
 
         // Convert normalized viewport (0-1) to canvas local position
-        canvasPosition = new Vector2((viewportPoint.x - 0.5f) * canvasRect.sizeDelta.x,
-            (viewportPoint.y - 0.5f) * canvasRect.sizeDelta.y);
+        canvasPosition = new Vector2((viewportPoint.x - 0.5f) * canvasSize.x * scaleFactor,
+            (viewportPoint.y - 0.5f) * canvasSize.y * scaleFactor);
 
         return true;
     }


### PR DESCRIPTION
## Describe your changes
Created a scale factor for user's actual resolution so that mouse movements are scaled & UI element doesn't overcompensate when using an optic. Also changed the canvas size to match the optic canvas size for normalization if an optic is used.

This change does not account for scope sway, but that is a minor issue which I may address in the future.

Tested with DLSS, FSR, and Super Sampling 2x & 0.5x. Nothing changed regardless of scaling.
Tested with 2560x1440, 1920x1080, and 5120x1440 (32:9) resolutions.
Tested with Vudu 1x/6x.

## Checklist before requesting a review
- [Y] I have performed a self-review of my code
- [Y] I have thoroughly tested the code changes
- [N] I have thoroughly tested the code changes on a dedicated session