### PR TITLE
Changes to allow connecting to an external Nat Punch Server

### DIFF
--- a/Fika.Core/FikaPlugin.cs
+++ b/Fika.Core/FikaPlugin.cs
@@ -357,7 +357,16 @@ public class FikaPlugin : BaseUnityPlugin
         var natPunchServerConfig = FikaRequestHandler.GetNatPunchServerConfig();
 
         NatPunchServerEnable = natPunchServerConfig.Enable;
-        NatPunchServerIP = RequestHandler.Host.Replace("https://", "").Split(':')[0];
+        
+        if (natPunchServerConfig.Ip == "")
+        {
+            NatPunchServerIP = RequestHandler.Host.Replace("https://", "").Split(':')[0];
+        }
+        else
+        {
+            NatPunchServerIP = natPunchServerConfig.Ip;
+        }
+        
         NatPunchServerPort = natPunchServerConfig.Port;
         NatPunchServerNatIntroduceAmount = natPunchServerConfig.NatIntroduceAmount;
 

--- a/Fika.Core/Networking/Models/NatPunchServerConfigModel.cs
+++ b/Fika.Core/Networking/Models/NatPunchServerConfigModel.cs
@@ -10,15 +10,19 @@ public struct NatPunchServerConfigModel
     [DataMember(Name = "enable")]
     public bool Enable;
 
+    [DataMember(Name = "ip")]
+    public string Ip;
+
     [DataMember(Name = "port")]
     public int Port;
 
     [DataMember(Name = "natIntroduceAmount")]
     public int NatIntroduceAmount;
 
-    public NatPunchServerConfigModel(bool enable, int port, int natIntroduceAmount)
+    public NatPunchServerConfigModel(bool enable, string ip, int port, int natIntroduceAmount)
     {
         Enable = enable;
+        Ip = ip;
         Port = port;
         NatIntroduceAmount = natIntroduceAmount;
     }


### PR DESCRIPTION
## Describe your changes
Changes to allow connecting to an external Nat Punch Server.
Empty IP in nat punch server config means it will use the local Nat Punch Server provided by Fika-Server.

## Related issue

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have thoroughly tested the code changes
- [x] I have thoroughly tested the code changes on a dedicated session