### PR TITLE
more flexible nat traversal

### DIFF
--- a/Fika.Core/FikaConfig.cs
+++ b/Fika.Core/FikaConfig.cs
@@ -758,7 +758,7 @@ public sealed class FikaConfig(ConfigFile config)
             }),
             "UDP Port", ref failed, headers);
 
-        UseUPnP = SetupSetting(networkDefaultHeader, "Use Port Mapping", true,
+        UseUPnP = SetupSetting(networkDefaultHeader, "Use Port Mapping", false,
             new ConfigDescription(LocaleUtils.BEPINEX_USE_UPNP_D.Localized(), tags: new ConfigurationManagerAttributes
             {
                 Category = networkHeader,
@@ -768,7 +768,7 @@ public sealed class FikaConfig(ConfigFile config)
             }),
             "Use UPnP", ref failed, headers);
 
-        UseNATPunching = SetupSetting(networkDefaultHeader, "Use NAT Punching", true,
+        UseNATPunching = SetupSetting(networkDefaultHeader, "Use NAT Punching", false,
             new ConfigDescription(LocaleUtils.BEPINEX_USE_NAT_PUNCH_D.Localized(), tags: new ConfigurationManagerAttributes
             {
                 Category = networkHeader,

--- a/Fika.Core/FikaConfig.cs
+++ b/Fika.Core/FikaConfig.cs
@@ -758,7 +758,7 @@ public sealed class FikaConfig(ConfigFile config)
             }),
             "UDP Port", ref failed, headers);
 
-        UseUPnP = SetupSetting(networkDefaultHeader, "Use UPnP", false,
+        UseUPnP = SetupSetting(networkDefaultHeader, "Use Port Mapping", true,
             new ConfigDescription(LocaleUtils.BEPINEX_USE_UPNP_D.Localized(), tags: new ConfigurationManagerAttributes
             {
                 Category = networkHeader,
@@ -768,7 +768,7 @@ public sealed class FikaConfig(ConfigFile config)
             }),
             "Use UPnP", ref failed, headers);
 
-        UseNATPunching = SetupSetting(networkDefaultHeader, "Use NAT Punching", false,
+        UseNATPunching = SetupSetting(networkDefaultHeader, "Use NAT Punching", true,
             new ConfigDescription(LocaleUtils.BEPINEX_USE_NAT_PUNCH_D.Localized(), tags: new ConfigurationManagerAttributes
             {
                 Category = networkHeader,

--- a/Fika.Core/Networking/FikaServer.cs
+++ b/Fika.Core/Networking/FikaServer.cs
@@ -222,30 +222,26 @@ public sealed partial class FikaServer : MonoBehaviour, INetEventListener, INatP
 #endif            
         await NetManagerUtils.CreateCoopHandler();
 
-        if (FikaPlugin.Instance.Settings.UseUPnP.Value && !FikaPlugin.Instance.Settings.UseNATPunching.Value)
-        {
-            var upnpFailed = false;
+        var portMapped=false;
 
+        if (FikaPlugin.Instance.Settings.UseUPnP.Value)
+        {
             try
             {
                 NatDiscoverer discoverer = new();
                 CancellationTokenSource cts = new(10000);
-                var device = await discoverer.DiscoverDeviceAsync(PortMapper.Upnp, cts);
+                var device = await discoverer.DiscoverDeviceAsync(PortMapper.Upnp | PortMapper.Pmp, cts);
                 var extIp = await device.GetExternalIPAsync();
                 _externalIp = extIp.MapToIPv4().ToString();
 
                 await device.CreatePortMapAsync(new Mapping(Protocol.Udp, _port, _port, 300, "Fika UDP"));
+
+                _logger.LogInfo("Port Mapping Succeeded");
+                portMapped=true;
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Error when attempting to map UPnP. Make sure the selected port is not already open! Exception: {ex.Message}");
-                upnpFailed = true;
-            }
-
-            if (upnpFailed)
-            {
-                Singleton<PreloaderUI>.Instance.ShowErrorScreen("Network Error", LocaleUtils.UI_UPNP_FAILED.Localized());
-                throw new MappingException("Error during mapping. Check log file for more information.");
+                _logger.LogWarning($"Port Mapping Failed: {ex.Message}");
             }
         }
         else if (FikaPlugin.Instance.Settings.ForceIP.Value != "")
@@ -263,8 +259,13 @@ public sealed partial class FikaServer : MonoBehaviour, INetEventListener, INatP
             _externalIp = FikaPlugin.Instance.WanIP.ToString();
         }
 
-        if (FikaPlugin.Instance.Settings.UseNATPunching.Value)
+        var useNATPunching = !portMapped && FikaPlugin.Instance.Settings.UseNATPunching.Value &&
+            (FikaPlugin.Instance.NatPunchServerEnable || FikaPlugin.Instance.Settings.UseFikaNATPunchServer.Value);
+
+        if (useNATPunching)
         {
+            _logger.LogInfo("NAT Punching Enabled");
+
             _netServer.NatPunchModule.UnsyncedEvents = true;
             _netServer.NatPunchModule.Init(this);
             _netServer.Start();
@@ -339,7 +340,7 @@ public sealed partial class FikaServer : MonoBehaviour, INetEventListener, INatP
                 iconType: EFT.Communications.ENotificationIconType.Alert);
         }
 
-        SetHostRequest body = new([.. ipAddresses], _port, FikaPlugin.Instance.Settings.UseNATPunching.Value,
+        SetHostRequest body = new([.. ipAddresses], _port, useNATPunching,
             FikaPlugin.Instance.Settings.UseFikaNATPunchServer.Value, FikaBackendUtils.IsHeadless);
         FikaRequestHandler.UpdateSetHost(body);
 


### PR DESCRIPTION
Implements client-side changes from #418 

port mapping and hole punching are no longer mutually exclusive options, and the NAT-PMP support built into Open.NAT has been enabled. The UPNP option has been renamed to "Port Mapping" to reflect this, and both are enabled by default. Option descriptions weren't updated as I couldn't find their sources in this repo.

With these changes, port mapping is attempted by default, but if it fails no error message is shown. Instead, a warning is logged and the client falls back to hole punching, which now has additional conditions for use. If the fika server doesn't have the hole punching feature enabled, or the client hasn't enabled the publicly hosted hole punch server option in the advanced settings, then hole punching is also disabled and the host doesn't use either nat traversal system, preventing a  mismatch in hole punching settings between client and server.

Both options remain toggle-able via the f12 menu, and logging calls were added so that the effective state of port mapping and hole punching can be easily determined for network troubleshooting. This should generally make it easier for peers to connect to a host, since applicable nat traversal strategies are automatically applied.