### PR TITLE
UDP Relay support

### DIFF
--- a/Fika.Core/FikaConfig.cs
+++ b/Fika.Core/FikaConfig.cs
@@ -798,7 +798,7 @@ public sealed class FikaConfig(ConfigFile config)
                 Order = 4,
                 IsAdvanced = true
             }),
-            "Use NAT Punching", ref failed, headers);
+            "Use Relay", ref failed, headers);
             
         ForceRelay = SetupSetting(networkDefaultHeader, "Force Relay", false,
             new ConfigDescription(LocaleUtils.BEPINEX_FORCE_RELAY_D.Localized(), tags: new ConfigurationManagerAttributes
@@ -808,7 +808,7 @@ public sealed class FikaConfig(ConfigFile config)
                 Order = 4,
                 IsAdvanced = true
             }),
-            "Use NAT Punching", ref failed, headers);
+            "Force Relay", ref failed, headers);
 
         ConnectionTimeout = SetupSetting(networkDefaultHeader, "Connection Timeout", 30,
             new ConfigDescription(LocaleUtils.BEPINEX_CONNECTION_TIMEOUT_D.Localized(),

--- a/Fika.Core/FikaConfig.cs
+++ b/Fika.Core/FikaConfig.cs
@@ -105,6 +105,8 @@ public sealed class FikaConfig(ConfigFile config)
     public ConfigEntry<int> ConnectionTimeout { get; set; }
     public ConfigEntry<ESendRate> SendRate { get; set; }
     public ConfigEntry<bool> UseFikaNATPunchServer { get; set; }
+    public ConfigEntry<bool> UseRelay { get; set; }
+    public ConfigEntry<bool> ForceRelay { get; set; }
     public ConfigEntry<bool> AllowVOIP { get; set; }
 
     // Gameplay
@@ -787,6 +789,26 @@ public sealed class FikaConfig(ConfigFile config)
                 IsAdvanced = true
             }),
             "Use Fika NAT Punch Server", ref failed, headers);
+            
+        UseRelay = SetupSetting(networkDefaultHeader, "Use Relay", false,
+            new ConfigDescription(LocaleUtils.BEPINEX_USE_RELAY_D.Localized(), tags: new ConfigurationManagerAttributes
+            {
+                Category = networkHeader,
+                DispName = LocaleUtils.BEPINEX_USE_RELAY_T.Localized(),
+                Order = 4,
+                IsAdvanced = true
+            }),
+            "Use NAT Punching", ref failed, headers);
+            
+        ForceRelay = SetupSetting(networkDefaultHeader, "Force Relay", false,
+            new ConfigDescription(LocaleUtils.BEPINEX_FORCE_RELAY_D.Localized(), tags: new ConfigurationManagerAttributes
+            {
+                Category = networkHeader,
+                DispName = LocaleUtils.BEPINEX_FORCE_RELAY_T.Localized(),
+                Order = 4,
+                IsAdvanced = true
+            }),
+            "Use NAT Punching", ref failed, headers);
 
         ConnectionTimeout = SetupSetting(networkDefaultHeader, "Connection Timeout", 30,
             new ConfigDescription(LocaleUtils.BEPINEX_CONNECTION_TIMEOUT_D.Localized(),

--- a/Fika.Core/Main/Utils/LocaleUtils.cs
+++ b/Fika.Core/Main/Utils/LocaleUtils.cs
@@ -335,6 +335,10 @@ public static class LocaleUtils
     public const string BEPINEX_USE_NAT_PUNCH_D = "F_BepInEx_UseNatPunch_D";
     public const string BEPINEX_USE_FIKA_NAT_PUNCH_SERVER_T = "F_BepInEx_UseFikaNatPunchServer_T";
     public const string BEPINEX_USE_FIKA_NAT_PUNCH_SERVER_D = "F_BepInEx_UseFikaNatPunchServer_D";
+    public const string BEPINEX_USE_RELAY_T = "F_BepInEx_UseRelayServer_T";
+    public const string BEPINEX_USE_RELAY_D = "F_BepInEx_UseRelayServer_D";
+    public const string BEPINEX_FORCE_RELAY_T = "F_BepInEx_ForceRelayServer_T";
+    public const string BEPINEX_FORCE_RELAY_D = "F_BepInEx_ForceRelayServer_D";
     public const string BEPINEX_CONNECTION_TIMEOUT_T = "F_BepInEx_ConnectionTimeout_T";
     public const string BEPINEX_CONNECTION_TIMEOUT_D = "F_BepInEx_ConnectionTimeout_D";
     public const string BEPINEX_SEND_RATE_T = "F_BepInEx_SendRate_T";

--- a/Fika.Core/Networking/FikaClient.cs
+++ b/Fika.Core/Networking/FikaClient.cs
@@ -193,7 +193,18 @@ public sealed partial class FikaClient : MonoBehaviour, INetEventListener, IFika
         }
         else
         {
-            ServerConnection = _netClient.Connect(FikaBackendUtils.RemoteEndPoint, connectString);
+            if(FikaPlugin.Instance.Settings.ForceRelay.Value){
+                // TODO Connect to relay
+            }
+            try {            
+                ServerConnection = _netClient.Connect(FikaBackendUtils.RemoteEndPoint, connectString);
+            } catch (Exception exception) {
+                if(FikaPlugin.Instance.Settings.UseRelay.Value){
+                    // TODO Connect to relay
+                } else {
+                    throw exception;
+                }
+            }
         }
     }
 

--- a/Fika.Core/Networking/FikaServer.cs
+++ b/Fika.Core/Networking/FikaServer.cs
@@ -348,6 +348,10 @@ public sealed partial class FikaServer : MonoBehaviour, INetEventListener, INatP
         {
             _raidAdminUIScript = RaidAdminUIScript.Create(this, _netServer);
         }
+
+        if (FikaPlugin.Instance.RelayServerEnable){
+            // TODO connect to relay server
+        }
     }
 
     public async Task InitializeVOIP()


### PR DESCRIPTION
[As requested](https://github.com/project-fika/Fika-Server-CSharp/issues/45#issuecomment-5043294729), here is my plan so far for the client-side changes to support the udp relay feature. Two client-side settings are added, UseRelay and ForceRelay, which control whether the client will fall back to a relay connection if a direct connection fails, or always use a relay connection (in case the connection to the server is more stable than the peer-to-peer connection). I've also added entries to LocaleUtils for these settings, but still not sure where the actual strings are being kept to be able to add their descriptions, some guidance on that would be appreciated.