### PR TITLE
Fix: prevent unintended downed state in solo play

### DIFF
--- a/Fika.Core/Main/ClientClasses/ClientHealthController.cs
+++ b/Fika.Core/Main/ClientClasses/ClientHealthController.cs
@@ -56,6 +56,11 @@ public sealed class ClientHealthController(Profile.HealthInfo healthInfo, Player
     {
         if (CoopHandler.TryGetCoopHandler(out var coopHandler))
         {
+            if (coopHandler.AmountOfHumans <= 1)
+            {
+                return false;
+            }
+
             return !coopHandler.AreAllHumanPlayersDead();
         }
 


### PR DESCRIPTION
## Problem

When playing solo as host with `ReviveConfig.Enabled = true`, the player always enters the downed state on death instead of dying normally.

### Root cause

`CanBeDowned` depends on `CanBeRevivedByOtherPlayer()`, which calls `coopHandler.AreAllHumanPlayersDead()`. That method skips the local player and checks `deadPlayers >= (AmountOfHumans - 1)`.

In solo play `AmountOfHumans = 1` (only yourself), so after skipping yourself `deadPlayers = 0` and the check becomes `0 >= 0` — **always true**. This means Fika believes someone can revive you even when nobody else is in the lobby, triggering an unintended downed state on death.

### Fix

Add an early return in `CanBeRevivedByOtherPlayer()`: if `AmountOfHumans <= 1`, return false immediately — there is no other player who could revive you.

```csharp
private bool CanBeRevivedByOtherPlayer()
{
    if (CoopHandler.TryGetCoopHandler(out var coopHandler))
    {
        if (coopHandler.AmountOfHumans <= 1)
            return false;

        return !coopHandler.AreAllHumanPlayersDead();
    }

    return false;
}
```

### Impact

- **Solo host**: `CanBeDowned` is now false → player dies normally on lethal damage. No behavior change for players who already had `ReviveConfig.Enabled = false`.
- **Coop (2+ humans)**: no change — `AmountOfHumans > 1` skips the new guard, existing logic applies.
- **Client-side players**: no change — the patch runs on `ClientHealthController.Kill` which is only active in Fika sessions.